### PR TITLE
Crashing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libboost-all-dev
 apt install libavformat-dev libswscale-dev libpng-dev libjpeg-dev libtiff-dev libwebp-dev
 ```
 
+Then configure, build, and run with
+```sh
+mkdir build ; cd build
+cmake ..
+cmake --build .
+cd .. ; ./build/WhoreMaster
+```
+
+By doing an out-of-source build like this, you can easily wipe your
+build by deleting the build directory. If you just want to keep your
+configuration and just rebuild, delete all build output with the
+command
+```sh
+make clean
+```
+
+To run the WhoreMaster binary, you need to be at the top of your
+working tree (where this file can be found), otherwise a number of
+hardcoded paths will be wrong.
+
 Note that the code uses C++14 features, and as such requires a relatively 
 recent version of GCC (>=7). If you get compile errors using a newer compiler,
 please submit a bug report or pull request.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ WM comes with a CMake build file that should make building relatively easy on li
 On Ubuntu-based distributions, the required dependencies can be obtained using
 ```sh
 apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libboost-all-dev
+apt install libavformat-dev libswscale-dev libpng-dev libjpeg-dev libtiff-dev libwebp-dev
 ```
+
 Note that the code uses C++14 features, and as such requires a relatively 
 recent version of GCC (>=7). If you get compile errors using a newer compiler,
 please submit a bug report or pull request.

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -1985,14 +1985,17 @@ void cJobManager::register_job(std::unique_ptr<IGenericJob> job) {
 }
 
 const IGenericJob* cJobManager::get_job(JOBS job) const {
-    if(job < 0 || job >= m_OOPJobs.size())
-      job = JOB_INDUNGEON;
+    if(job < 0 || job >= m_OOPJobs.size()) {
+      g_LogFile.error("jobmgr",
+		      "Job ", job, " is outside the (0..", m_OOPJobs.size(), "( range.");
+      throw std::out_of_range("cJobManager::get_job()");
+    }
 
     auto& ptr = m_OOPJobs[job];
     if(!ptr) {
-      // this one NEEDS to be non-null.
-      assert(m_OOPJobs[JOB_INDUNGEON].get() != nullptr);
-      return m_OOPJobs[JOB_INDUNGEON].get();
+      g_LogFile.error("jobmgr",
+		      "Job ", job, " has not been registered.");
+      throw std::invalid_argument("cJobManager::get_job()");
     }
 
     return ptr.get();

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -251,6 +251,7 @@ void cJobManager::do_custjobs(IBuilding& brothel, bool Day0Night1)
 
 bool cJobManager::FullTimeJob(JOBS Job)
 {
+    assert(m_OOPJobs.at(Job) != nullptr);
     return m_OOPJobs.at(Job)->get_info().FullTime;
 }
 
@@ -451,6 +452,7 @@ bool cJobManager::HandleSpecialJobs(sGirl& Girl, JOBS JobID, JOBS OldJobID, bool
     if(Girl.m_Building)
         rest = JOB_RESTING;
 
+    assert(m_OOPJobs[JobID] != nullptr);
     auto check = m_OOPJobs[JobID]->is_job_valid(Girl);
     if(!check) {
         g_Game->push_message(check.Reason, 0);
@@ -1868,6 +1870,7 @@ bool cJobManager::do_job(sGirl& girl, bool is_night)
 
 bool cJobManager::do_job(JOBS job_id, sGirl& girl, bool is_night)
 {
+    assert(m_OOPJobs[job_id] != nullptr);
     auto refused = m_OOPJobs[job_id]->Work(girl, is_night, g_Dice);
     if(is_night) {
         girl.m_Refused_To_Work_Night = refused;
@@ -1977,6 +1980,7 @@ void cJobManager::CatchGirl(sGirl& girl, std::stringstream& fuckMessage, const s
 }
 
 void cJobManager::register_job(std::unique_ptr<IGenericJob> job) {
+    assert(job != nullptr);
     m_OOPJobs[job->job()] = std::move(job);
 }
 
@@ -1985,14 +1989,17 @@ const IGenericJob* cJobManager::get_job(JOBS job) const {
 }
 
 const std::string& cJobManager::get_job_name(JOBS job) const {
+    assert(get_job(job) != nullptr);
     return get_job(job)->get_info().Name;
 }
 
 const std::string& cJobManager::get_job_brief(JOBS job) const {
+    assert(get_job(job) != nullptr);
     return get_job(job)->get_info().ShortName;
 }
 
 const std::string& cJobManager::get_job_description(JOBS job) const {
+    assert(get_job(job) != nullptr);
     return get_job(job)->get_info().Description;
 }
 

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -1985,7 +1985,17 @@ void cJobManager::register_job(std::unique_ptr<IGenericJob> job) {
 }
 
 const IGenericJob* cJobManager::get_job(JOBS job) const {
-    return m_OOPJobs.at(job).get();
+    if(job < 0 || job >= m_OOPJobs.size())
+      job = JOB_INDUNGEON;
+
+    auto& ptr = m_OOPJobs[job];
+    if(!ptr) {
+      // this one NEEDS to be non-null.
+      assert(m_OOPJobs[JOB_INDUNGEON].get() != nullptr);
+      return m_OOPJobs[JOB_INDUNGEON].get();
+    }
+
+    return ptr.get();
 }
 
 const std::string& cJobManager::get_job_name(JOBS job) const {

--- a/src/game/jobs/GenericJob.cpp
+++ b/src/game/jobs/GenericJob.cpp
@@ -182,6 +182,11 @@ DECL_JOB(SOBisexual);
 DECL_JOB(SOLesbian);
 DECL_JOB(FakeOrgasm);
 
+namespace {
+  bool WorkNullJob(sGirl&, bool, cRng&) { return false; }
+  double JP_NullJob(const sGirl&, bool) { return 0.0; }
+}
+
 #define REGISTER_JOB_MANUAL(J, Wf, Pf, Brief, Desc)                                     \
     [&]() -> auto& {                                                                    \
     auto new_job = std::make_unique<cJobWrapper>(J, Work##Wf, JP_##Pf, Brief, Desc);    \
@@ -267,6 +272,10 @@ void RegisterWrappedJobs(cJobManager& mgr) {
     REGISTER_JOB(JOB_SO_BISEXUAL, SOBisexual, "SOBi", "You will make sure she likes having sex with both men and women.").full_time();
     REGISTER_JOB(JOB_SO_LESBIAN, SOLesbian, "SOLe", "You will make sure she only likes having sex with women.").full_time();
     REGISTER_JOB(JOB_FAKEORGASM, FakeOrgasm, "FOEx", "You will teach her how to fake her orgasms.").full_time();
+
+    // Some pseudo-jobs
+    REGISTER_JOB(JOB_INDUNGEON, NullJob, "", "She is languishing in the dungeon.");
+    REGISTER_JOB(JOB_RUNAWAY, NullJob, "", "She has escaped.");
 }
 
 double cBasicJob::GetPerformance(const sGirl& girl, bool estimate) const {


### PR DESCRIPTION
JOB_INDUNGEON and JOB_RUNAWAY weren't regged with the job manager, so segfaults happened. I added do-nothing registrations for them, and a few asserts to spell out the assumptions in the code.

Oops! A quick test run convinced me that `cJobManager::get_job()` needed a range check. While I was at it, I added a null check as well -- so now I think I've hardened the function _almost_ enough to return a reference instead of a pointer.

(And most of the commits here are me trying to sync my master branch with yours. Sorry about that.)