### PR TITLE
Sorting the tables properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libboost-all-dev
 apt install libavformat-dev libswscale-dev libpng-dev libjpeg-dev libtiff-dev libwebp-dev
 ```
 
+Then configure, build, and run with
+```sh
+mkdir build ; cd build
+cmake ..
+cmake --build .
+cd .. ; ./build/WhoreMaster
+```
+
+By doing an out-of-source build like this, you can easily wipe your
+build by deleting the build directory. If you just want to keep your
+configuration and just rebuild, delete all build output with the
+command
+```sh
+make clean
+```
+
+To run the WhoreMaster binary, you need to be at the top of your
+working tree (where this file can be found), otherwise a number of
+hardcoded paths will be wrong.
+
 Note that the code uses C++14 features, and as such requires a relatively 
 recent version of GCC (>=7). If you get compile errors using a newer compiler,
 please submit a bug report or pull request.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ WM comes with a CMake build file that should make building relatively easy on li
 On Ubuntu-based distributions, the required dependencies can be obtained using
 ```sh
 apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libboost-all-dev
+apt install libavformat-dev libswscale-dev libpng-dev libjpeg-dev libtiff-dev libwebp-dev
 ```
+
 Note that the code uses C++14 features, and as such requires a relatively 
 recent version of GCC (>=7). If you get compile errors using a newer compiler,
 please submit a bug report or pull request.

--- a/Resources/Interface/J_1024x768/arena_management_screen.xml
+++ b/Resources/Interface/J_1024x768/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="633" />
-<Column     Name="SKILL_Magic"          Header="Magic"                      Offset="670" />
-<Column     Name="SKILL_Combat"         Header="Combat"                     Offset="707" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="596" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="633" />
+<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="670" />
+<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/centre_management_screen.xml
+++ b/Resources/Interface/J_1024x768/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="is_addict"            Header="Addict"                     Offset="633" />
-<Column     Name="SKILL_Service"        Header="Service"                    Offset="670" />
-<Column     Name="STAT_Charisma"        Header="Charisma"                   Offset="707" />
+<Column     Name="Name"          Type="String"        Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Type="Numeric"       Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"     Type="Numeric"       Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"     Type="Numeric"       Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"        Type="String"        Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"      Type="String"        Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"   Type="String"        Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"      Type="String"        Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"         Type="Numeric"       Header="Rebel"                      Offset="559" />
+<Column     Name="Age"           Type="Numeric"       Header="Age"                        Offset="596" />
+<Column     Name="is_addict"     Type="String"        Header="Addict"                     Offset="633" />
+<Column     Name="SKILL_Service" Type="Numeric"       Header="Service"                    Offset="670" />
+<Column     Name="STAT_Charisma" Type="Numeric"       Header="Charisma"                   Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/clinic_management_screen.xml
+++ b/Resources/Interface/J_1024x768/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="has_disease"          Header="Disease"                    Offset="633" />
-<Column     Name="STAT_Intelligence"    Header="Int."                       Offset="670" />
-<Column     Name="SKILL_Medicine"       Header="Medicine"                   Offset="707" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="596" />
+<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="633" />
+<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="670" />
+<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/dungeon_screen.xml
+++ b/Resources/Interface/J_1024x768/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="847"     YPos="690"      Width="150"     Height="40"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="632"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0"  />                                   
-<Column     Name="Health"               Header="Health"                     Offset="150"  />                                 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187"  />                                 
-<Column     Name="Rebelliousness"       Header="Rebel"                      Offset="224"  />                                 
-<Column     Name="is_slave"             Header="Slave"                      Offset="261"  />                                 
-<Column     Name="is_addict"            Header="Addict"                     Offset="317"  />                                 
-<Column     Name="has_disease"          Header="Disease"                    Offset="373"  />                                 
-<Column     Name="Duration"             Header="Weeks In"                   Offset="429"  />                                 
-<Column     Name="Feeding"              Header="Feeding"                    Offset="485"  />                                 
-<Column     Name="Tortured"             Header="Tortured"                   Offset="541"  />                                 
-<Column     Name="Reason"               Header="Reason for Imprisonment"    Offset="597"  />                                 
+<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="150"  />
+<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="187"  />
+<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="224"  />
+<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="261"  />
+<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="317"  />
+<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="373"  />
+<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="429"  />
+<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="485"  />
+<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="541"  />
+<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="597"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="262"      YPos="670"      Width="262"     Height="24"  FontSize="12"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="562"      YPos="670"      Width="150"     Height="24"  FontSize="12"  />

--- a/Resources/Interface/J_1024x768/farm_management_screen.xml
+++ b/Resources/Interface/J_1024x768/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="633" />
-<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="670" />
-<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="707" />
+<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="559" />
+<Column     Name="Age"                  Type="Numeric" Header="Age"                        Offset="596" />
+<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="633" />
+<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="670" />
+<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/gangs_screen.xml
+++ b/Resources/Interface/J_1024x768/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="7"       YPos="35"       Width="825"     Height="402" FontSize="9" RowHeight="19" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"              Header="Mission"                    Offset="187"  />
-<Column     Name="Number"               Header="Men"                        Offset="299"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="355"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="411"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="467"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="523"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="579"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="635"  />
-<Column     Name="Service"              Header="Service"                    Offset="691"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="747"  />
+<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="187"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="299"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="355"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="411"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="467"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="523"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="579"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="635"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="691"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="747"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="37"       YPos="425"      Width="45"      Height="44"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="87"      YPos="520"      Width="60"      Height="32"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="157"      YPos="450"      Width="675"     Height="182" FontSize="9" RowHeight="19" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"               Header="Men"                        Offset="150"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="206"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="262"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="318"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="374"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="430"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="486"  />
-<Column     Name="Service"              Header="Service"                    Offset="542"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="598"  />
+<Column     Name="GangName"      Type="String"        Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"        Type="Numeric"       Header="Men"                        Offset="150"  />
+<Column     Name="Combat"        Type="Numeric"       Header="Combat"                     Offset="206"  />
+<Column     Name="Magic"         Type="Numeric"       Header="Magic"                      Offset="262"  />
+<Column     Name="Intelligence"  Type="Numeric"       Header="Intel."                     Offset="318"  />
+<Column     Name="Agility"       Type="Numeric"       Header="Agility"                    Offset="374"  />
+<Column     Name="Constitution"  Type="Numeric"       Header="Tough"                      Offset="430"  />
+<Column     Name="Strength"      Type="Numeric"       Header="Strength"                   Offset="486"  />
+<Column     Name="Service"       Type="Numeric"       Header="Service"                    Offset="542"  />
+<Column     Name="Charisma"      Type="Numeric"       Header="Charisma"                   Offset="598"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="847"     YPos="8"        Width="150"     Height="32"  FontSize="13"  />

--- a/Resources/Interface/J_1024x768/girl_management_screen.xml
+++ b/Resources/Interface/J_1024x768/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="Looks"                Header="Looks"                      Offset="633" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="670" />
-<Column     Name="SexAverage"           Header="Avg.Sex"                    Offset="707" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="596" />
+<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="633" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="670" />
+<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/house_management_screen.xml
+++ b/Resources/Interface/J_1024x768/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="SO"                   Header="SO"                         Offset="633" />
-<Column     Name="STAT_PCLove"          Header="Love"                       Offset="670" />
-<Column     Name="SkillAverage"         Header="Skill Avg."                 Offset="707" />
+<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="559" />
+<Column     Name="Age"          Type="Numeric"        Header="Age"                        Offset="596" />
+<Column     Name="SO"           Type="String"         Header="SO"                         Offset="633" />
+<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="670" />
+<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/studio_management_screen.xml
+++ b/Resources/Interface/J_1024x768/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="862"     YPos="650"      Width="120"     Height="32"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Header="Age"                        Offset="596" />
-<Column     Name="Looks"                Header="Looks"                      Offset="633" />
-<Column     Name="STAT_Fame"            Header="Fame"                       Offset="670" />
-<Column     Name="SKILL_Performance"    Header="Perform"                    Offset="707" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="150" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="596" />
+<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="633" />
+<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="670" />
+<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/arena_management_screen.xml
+++ b/Resources/Interface/J_1366x768/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="850" />
-<Column     Name="SKILL_Magic"          Header="Magic"                      Offset="900" />
-<Column     Name="SKILL_Combat"         Header="Combat"                     Offset="950" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="800" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="850" />
+<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="900" />
+<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/centre_management_screen.xml
+++ b/Resources/Interface/J_1366x768/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="is_addict"            Header="Addict"                     Offset="850" />
-<Column     Name="SKILL_Service"        Header="Service"                    Offset="900" />
-<Column     Name="STAT_Charisma"        Header="Charisma"                   Offset="950" />
+<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="750" />
+<Column     Name="Age"           Type="Numeric"        Header="Age"                        Offset="800" />
+<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="850" />
+<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="900" />
+<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/clinic_management_screen.xml
+++ b/Resources/Interface/J_1366x768/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="has_disease"          Header="Disease"                    Offset="850" />
-<Column     Name="STAT_Intelligence"    Header="Int."                       Offset="900" />
-<Column     Name="SKILL_Medicine"       Header="Medicine"                   Offset="950" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="800" />
+<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="850" />
+<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="900" />
+<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/dungeon_screen.xml
+++ b/Resources/Interface/J_1366x768/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="1130"     YPos="690"      Width="200"     Height="40"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="632"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0"  />                                   
-<Column     Name="Health"               Header="Health"                     Offset="200"  />                                 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250"  />                                 
-<Column     Name="Rebelliousness"       Header="Rebel"                      Offset="300"  />                                 
-<Column     Name="is_slave"             Header="Slave"                      Offset="350"  />                                 
-<Column     Name="is_addict"            Header="Addict"                     Offset="425"  />                                 
-<Column     Name="has_disease"          Header="Disease"                    Offset="500"  />                                 
-<Column     Name="Duration"             Header="Weeks In"                   Offset="575"  />                                 
-<Column     Name="Feeding"              Header="Feeding"                    Offset="650"  />                                 
-<Column     Name="Tortured"             Header="Tortured"                   Offset="725"  />                                 
-<Column     Name="Reason"               Header="Reason for Imprisonment"    Offset="800"  />                                 
+<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="200"  />
+<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="250"  />
+<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="300"  />
+<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="350"  />
+<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="425"  />
+<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="500"  />
+<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="575"  />
+<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="650"  />
+<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="725"  />
+<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="800"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="350"      YPos="670"      Width="350"     Height="24"  FontSize="16"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="750"      YPos="670"      Width="200"     Height="24"  FontSize="16"  />

--- a/Resources/Interface/J_1366x768/farm_management_screen.xml
+++ b/Resources/Interface/J_1366x768/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="850" />
-<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="900" />
-<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="950" />
+<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="750" />
+<Column     Name="Age"                  Type="Numeric" Header="Age"                        Offset="800" />
+<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="850" />
+<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="900" />
+<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/gangs_screen.xml
+++ b/Resources/Interface/J_1366x768/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="10"       YPos="35"       Width="1100"     Height="402" FontSize="12" RowHeight="19" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"              Header="Mission"                    Offset="250"  />
-<Column     Name="Number"               Header="Men"                        Offset="400"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="475"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="550"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="625"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="700"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="775"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="850"  />
-<Column     Name="Service"              Header="Service"                    Offset="925"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="1000"  />
+<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="250"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="400"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="475"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="550"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="625"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="700"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="775"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="850"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="925"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1000"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="50"       YPos="425"      Width="60"      Height="44"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="116"      YPos="520"      Width="80"      Height="32"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="210"      YPos="450"      Width="900"     Height="182" FontSize="12" RowHeight="19" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"               Header="Men"                        Offset="200"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="275"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="350"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="425"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="500"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="575"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="650"  />
-<Column     Name="Service"              Header="Service"                    Offset="725"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="800"  />
+<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="200"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="275"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="350"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="425"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="500"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="575"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="650"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="725"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="800"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="1130"     YPos="8"        Width="200"     Height="32"  FontSize="18"  />

--- a/Resources/Interface/J_1366x768/girl_management_screen.xml
+++ b/Resources/Interface/J_1366x768/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="Looks"                Header="Looks"                      Offset="850" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="900" />
-<Column     Name="SexAverage"           Header="Avg.Sex"                    Offset="950" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="800" />
+<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="850" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="900" />
+<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/house_management_screen.xml
+++ b/Resources/Interface/J_1366x768/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="SO"                   Header="SO"                         Offset="850" />
-<Column     Name="STAT_PCLove"          Header="Love"                       Offset="900" />
-<Column     Name="SkillAverage"         Header="Skill Avg."                 Offset="950" />
+<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="750" />
+<Column     Name="Age"          Type="Numeric"        Header="Age"                        Offset="800" />
+<Column     Name="SO"           Type="String"         Header="SO"                         Offset="850" />
+<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="900" />
+<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/studio_management_screen.xml
+++ b/Resources/Interface/J_1366x768/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1150"     YPos="650"      Width="160"     Height="32"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Header="Age"                        Offset="800" />
-<Column     Name="Looks"                Header="Looks"                      Offset="850" />
-<Column     Name="STAT_Fame"            Header="Fame"                       Offset="900" />
-<Column     Name="SKILL_Performance"    Header="Perform"                    Offset="950" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="800" />
+<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="850" />
+<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="900" />
+<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/arena_management_screen.xml
+++ b/Resources/Interface/J_1600x900/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="999" />
-<Column     Name="SKILL_Magic"          Header="Magic"                      Offset="1058" />
-<Column     Name="SKILL_Combat"         Header="Combat"                     Offset="1117" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="940" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="999" />
+<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="1058" />
+<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/centre_management_screen.xml
+++ b/Resources/Interface/J_1600x900/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="is_addict"            Header="Addict"                     Offset="999" />
-<Column     Name="SKILL_Service"        Header="Service"                    Offset="1058" />
-<Column     Name="STAT_Charisma"        Header="Charisma"                   Offset="1117" />
+<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="881" />
+<Column     Name="Age"           Type="Numeric"        Header="Age"                        Offset="940" />
+<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="999" />
+<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="1058" />
+<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/clinic_management_screen.xml
+++ b/Resources/Interface/J_1600x900/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="has_disease"          Header="Disease"                    Offset="999" />
-<Column     Name="STAT_Intelligence"    Header="Int."                       Offset="1058" />
-<Column     Name="SKILL_Medicine"       Header="Medicine"                   Offset="1117" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="940" />
+<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="999" />
+<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="1058" />
+<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/dungeon_screen.xml
+++ b/Resources/Interface/J_1600x900/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="1324"     YPos="809"      Width="234"     Height="47"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="741"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0"  />                                   
-<Column     Name="Health"               Header="Health"                     Offset="234"  />                                 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293"  />                                 
-<Column     Name="Rebelliousness"       Header="Rebel"                      Offset="352"  />                                 
-<Column     Name="is_slave"             Header="Slave"                      Offset="411"  />                                 
-<Column     Name="is_addict"            Header="Addict"                     Offset="499"  />                                 
-<Column     Name="has_disease"          Header="Disease"                    Offset="587"  />                                 
-<Column     Name="Duration"             Header="Weeks In"                   Offset="675"  />                                 
-<Column     Name="Feeding"              Header="Feeding"                    Offset="763"  />                                 
-<Column     Name="Tortured"             Header="Tortured"                   Offset="851"  />                                 
-<Column     Name="Reason"               Header="Reason for Imprisonment"    Offset="939"  />                                 
+<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="234"  />
+<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="293"  />
+<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="352"  />
+<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="411"  />
+<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="499"  />
+<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="587"  />
+<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="675"  />
+<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="763"  />
+<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="851"  />
+<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="939"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="410"      YPos="785"      Width="410"     Height="28"  FontSize="19"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="878"      YPos="785"      Width="234"     Height="28"  FontSize="19"  />

--- a/Resources/Interface/J_1600x900/farm_management_screen.xml
+++ b/Resources/Interface/J_1600x900/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="999" />
-<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="1058" />
-<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="1117" />
+<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="881" />
+<Column     Name="Age"                  Type="Numeric" Header="Age"                        Offset="940" />
+<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="999" />
+<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="1058" />
+<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/gangs_screen.xml
+++ b/Resources/Interface/J_1600x900/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="12"       YPos="41"       Width="1288"     Height="471" FontSize="14" RowHeight="22" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"              Header="Mission"                    Offset="293"  />
-<Column     Name="Number"               Header="Men"                        Offset="469"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="557"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="645"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="733"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="821"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="909"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="997"  />
-<Column     Name="Service"              Header="Service"                    Offset="1085"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="1173"  />
+<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="293"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="469"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="557"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="645"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="733"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="821"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="909"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="997"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="1085"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1173"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="59"       YPos="498"      Width="70"      Height="52"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="136"      YPos="609"      Width="94"      Height="38"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="246"      YPos="527"      Width="1054"     Height="213" FontSize="14" RowHeight="22" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"               Header="Men"                        Offset="234"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="322"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="410"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="498"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="586"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="674"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="762"  />
-<Column     Name="Service"              Header="Service"                    Offset="850"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="938"  />
+<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="234"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="322"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="410"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="498"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="586"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="674"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="762"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="850"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="938"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="1324"     YPos="9"        Width="234"     Height="38"  FontSize="21"  />

--- a/Resources/Interface/J_1600x900/girl_management_screen.xml
+++ b/Resources/Interface/J_1600x900/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="Looks"                Header="Looks"                      Offset="999" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="1058" />
-<Column     Name="SexAverage"           Header="Avg.Sex"                    Offset="1117" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="940" />
+<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="999" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="1058" />
+<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/house_management_screen.xml
+++ b/Resources/Interface/J_1600x900/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="SO"                   Header="SO"                         Offset="999" />
-<Column     Name="STAT_PCLove"          Header="Love"                       Offset="1058" />
-<Column     Name="SkillAverage"         Header="Skill Avg."                 Offset="1117" />
+<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="881" />
+<Column     Name="Age"          Type="Numeric"        Header="Age"                        Offset="940" />
+<Column     Name="SO"           Type="String"         Header="SO"                         Offset="999" />
+<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="1058" />
+<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/studio_management_screen.xml
+++ b/Resources/Interface/J_1600x900/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1347"     YPos="762"      Width="187"     Height="38"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Header="Age"                        Offset="940" />
-<Column     Name="Looks"                Header="Looks"                      Offset="999" />
-<Column     Name="STAT_Fame"            Header="Fame"                       Offset="1058" />
-<Column     Name="SKILL_Performance"    Header="Perform"                    Offset="1117" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="940" />
+<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="999" />
+<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="1058" />
+<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/arena_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="1193" />
-<Column     Name="SKILL_Magic"          Header="Magic"                      Offset="1263" />
-<Column     Name="SKILL_Combat"         Header="Combat"                     Offset="1333" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="1123" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="1193" />
+<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="1263" />
+<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/centre_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="is_addict"            Header="Addict"                     Offset="1193" />
-<Column     Name="SKILL_Service"        Header="Service"                    Offset="1263" />
-<Column     Name="STAT_Charisma"        Header="Charisma"                   Offset="1333" />
+<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"           Type="Numeric"        Header="Age"                        Offset="1123" />
+<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="1193" />
+<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="1263" />
+<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/clinic_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="has_disease"          Header="Disease"                    Offset="1193" />
-<Column     Name="STAT_Intelligence"    Header="Int."                       Offset="1263" />
-<Column     Name="SKILL_Medicine"       Header="Medicine"                   Offset="1333" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Type="Numeric"    Header="Age"                        Offset="1123" />
+<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="1193" />
+<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="1263" />
+<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/dungeon_screen.xml
+++ b/Resources/Interface/J_1920x1080/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="1588"     YPos="970"      Width="281"     Height="56"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="889"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0"  />                                   
-<Column     Name="Health"               Header="Health"                     Offset="281"  />                                 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351"  />                                 
-<Column     Name="Rebelliousness"       Header="Rebel"                      Offset="421"  />                                 
-<Column     Name="is_slave"             Header="Slave"                      Offset="491"  />                                 
-<Column     Name="is_addict"            Header="Addict"                     Offset="596"  />                                 
-<Column     Name="has_disease"          Header="Disease"                    Offset="701"  />                                 
-<Column     Name="Duration"             Header="Weeks In"                   Offset="806"  />                                 
-<Column     Name="Feeding"              Header="Feeding"                    Offset="911"  />                                 
-<Column     Name="Tortured"             Header="Tortured"                   Offset="1016"  />                                 
-<Column     Name="Reason"               Header="Reason for Imprisonment"    Offset="1121"  />                                 
+<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="281"  />
+<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="351"  />
+<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="421"  />
+<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="491"  />
+<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="596"  />
+<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="701"  />
+<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="806"  />
+<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="911"  />
+<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="1016"  />
+<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="1121"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="492"      YPos="942"      Width="492"     Height="34"  FontSize="22"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="1054"      YPos="942"      Width="281"     Height="34"  FontSize="22"  />

--- a/Resources/Interface/J_1920x1080/farm_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="1193" />
-<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="1263" />
-<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="1333" />
+<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"                  Type="Numeric" Header="Age"                        Offset="1123" />
+<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="1193" />
+<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="1263" />
+<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/gangs_screen.xml
+++ b/Resources/Interface/J_1920x1080/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="14"       YPos="49"       Width="1546"     Height="565" FontSize="17" RowHeight="27" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"              Header="Mission"                    Offset="351"  />
-<Column     Name="Number"               Header="Men"                        Offset="562"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="667"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="772"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="877"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="982"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="1087"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="1192"  />
-<Column     Name="Service"              Header="Service"                    Offset="1297"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="1402"  />
+<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="351"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="562"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="667"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="772"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="877"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="982"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="1087"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="1192"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="1297"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1402"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="70"       YPos="598"      Width="84"      Height="62"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="163"      YPos="731"      Width="112"      Height="45"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="295"      YPos="633"      Width="1265"     Height="256" FontSize="17" RowHeight="27" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"               Header="Men"                        Offset="281"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="386"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="491"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="596"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="701"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="806"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="911"  />
-<Column     Name="Service"              Header="Service"                    Offset="1016"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="1121"  />
+<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="281"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="386"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="491"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="596"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="701"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="806"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="911"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="1016"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1121"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="1588"     YPos="11"        Width="281"     Height="45"  FontSize="25"  />

--- a/Resources/Interface/J_1920x1080/girl_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="Looks"                Header="Looks"                      Offset="1193" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="1263" />
-<Column     Name="SexAverage"           Header="Avg.Sex"                    Offset="1333" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="1123" />
+<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="1193" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="1263" />
+<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/house_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="SO"                   Header="SO"                         Offset="1193" />
-<Column     Name="STAT_PCLove"          Header="Love"                       Offset="1263" />
-<Column     Name="SkillAverage"         Header="Skill Avg."                 Offset="1333" />
+<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"          Type="Numeric"        Header="Age"                        Offset="1123" />
+<Column     Name="SO"           Type="String"         Header="SO"                         Offset="1193" />
+<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="1263" />
+<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/studio_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1616"     YPos="914"      Width="225"     Height="45"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Header="Age"                        Offset="1123" />
-<Column     Name="Looks"                Header="Looks"                      Offset="1193" />
-<Column     Name="STAT_Fame"            Header="Fame"                       Offset="1263" />
-<Column     Name="SKILL_Performance"    Header="Perform"                    Offset="1333" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="1123" />
+<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="1193" />
+<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="1263" />
+<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/arena_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="2393" />
-<Column     Name="SKILL_Magic"          Header="Magic"                      Offset="2534" />
-<Column     Name="SKILL_Combat"         Header="Combat"                     Offset="2675" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="2252" />
+<Column     Name="STAT_Constitution" Type="Numeric"   Header="Const."                     Offset="2393" />
+<Column     Name="SKILL_Magic"       Type="Numeric"   Header="Magic"                      Offset="2534" />
+<Column     Name="SKILL_Combat"      Type="Numeric"   Header="Combat"                     Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/centre_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="is_addict"            Header="Addict"                     Offset="2393" />
-<Column     Name="SKILL_Service"        Header="Service"                    Offset="2534" />
-<Column     Name="STAT_Charisma"        Header="Charisma"                   Offset="2675" />
+<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"           Type="Numeric"        Header="Age"                        Offset="2252" />
+<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="2393" />
+<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="2534" />
+<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/clinic_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="has_disease"          Header="Disease"                    Offset="2393" />
-<Column     Name="STAT_Intelligence"    Header="Int."                       Offset="2534" />
-<Column     Name="SKILL_Medicine"       Header="Medicine"                   Offset="2675" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="2252" />
+<Column     Name="has_disease"       Type="String"    Header="Disease"                    Offset="2393" />
+<Column     Name="STAT_Intelligence" Type="Numeric"   Header="Int."                       Offset="2534" />
+<Column     Name="SKILL_Medicine"    Type="Numeric"   Header="Medicine"                   Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/dungeon_screen.xml
+++ b/Resources/Interface/J_3840x2160/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="3177"     YPos="1941"      Width="562"     Height="112"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1778"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0"  />                                   
-<Column     Name="Health"               Header="Health"                     Offset="562"  />                                 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703"  />                                 
-<Column     Name="Rebelliousness"       Header="Rebel"                      Offset="844"  />                                 
-<Column     Name="is_slave"             Header="Slave"                      Offset="985"  />                                 
-<Column     Name="is_addict"            Header="Addict"                     Offset="1196"  />                                 
-<Column     Name="has_disease"          Header="Disease"                    Offset="1407"  />                                 
-<Column     Name="Duration"             Header="Weeks In"                   Offset="1618"  />                                 
-<Column     Name="Feeding"              Header="Feeding"                    Offset="1829"  />                                 
-<Column     Name="Tortured"             Header="Tortured"                   Offset="2040"  />                                 
-<Column     Name="Reason"               Header="Reason for Imprisonment"    Offset="2251"  />                                 
+<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="562"  />
+<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="703"  />
+<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="844"  />
+<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="985"  />
+<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="1196"  />
+<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="1407"  />
+<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="1618"  />
+<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="1829"  />
+<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="2040"  />
+<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="2251"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="984"      YPos="1884"      Width="984"     Height="68"  FontSize="45"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="2108"      YPos="1884"      Width="562"     Height="68"  FontSize="45"  />

--- a/Resources/Interface/J_3840x2160/farm_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="2393" />
-<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="2534" />
-<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="2675" />
+<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"                  Type="Numeric" Header="Age"                        Offset="2252" />
+<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="2393" />
+<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="2534" />
+<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/gangs_screen.xml
+++ b/Resources/Interface/J_3840x2160/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="28"       YPos="98"       Width="3092"     Height="1131" FontSize="34" RowHeight="53" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"              Header="Mission"                    Offset="703"  />
-<Column     Name="Number"               Header="Men"                        Offset="1125"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="1336"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="1547"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="1758"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="1969"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="2180"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="2391"  />
-<Column     Name="Service"              Header="Service"                    Offset="2602"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="2813"  />
+<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="703"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="1125"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="1336"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="1547"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="1758"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="1969"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="2180"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="2391"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="2602"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="2813"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="141"       YPos="1195"      Width="169"      Height="124"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="326"      YPos="1462"      Width="225"      Height="90"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="590"      YPos="1266"      Width="2530"     Height="512" FontSize="34" RowHeight="53" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"             Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"               Header="Men"                        Offset="562"  />
-<Column     Name="Combat"               Header="Combat"                     Offset="773"  />
-<Column     Name="Magic"                Header="Magic"                      Offset="984"  />
-<Column     Name="Intelligence"         Header="Intel."                     Offset="1195"  />
-<Column     Name="Agility"              Header="Agility"                    Offset="1406"  />
-<Column     Name="Constitution"         Header="Tough"                      Offset="1617"  />
-<Column     Name="Strength"             Header="Strength"                   Offset="1828"  />
-<Column     Name="Service"              Header="Service"                    Offset="2039"  />
-<Column     Name="Charisma"             Header="Charisma"                   Offset="2250"  />
+<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="562"  />
+<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="773"  />
+<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="984"  />
+<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="1195"  />
+<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="1406"  />
+<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="1617"  />
+<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="1828"  />
+<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="2039"  />
+<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="2250"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="3177"     YPos="22"        Width="562"     Height="90"  FontSize="51"  />

--- a/Resources/Interface/J_3840x2160/girl_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="Looks"                Header="Looks"                      Offset="2393" />
-<Column     Name="STAT_Constitution"    Header="Const."                     Offset="2534" />
-<Column     Name="SexAverage"           Header="Avg.Sex"                    Offset="2675" />
+<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="2252" />
+<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="2393" />
+<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="2534" />
+<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/house_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="SO"                   Header="SO"                         Offset="2393" />
-<Column     Name="STAT_PCLove"          Header="Love"                       Offset="2534" />
-<Column     Name="SkillAverage"         Header="Skill Avg."                 Offset="2675" />
+<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"          Type="Numeric"        Header="Age"                        Offset="2252" />
+<Column     Name="SO"           Type="String"         Header="SO"                         Offset="2393" />
+<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="2534" />
+<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/studio_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="3233"     YPos="1828"      Width="450"     Height="90"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Header="Age"                        Offset="2252" />
-<Column     Name="Looks"                Header="Looks"                      Offset="2393" />
-<Column     Name="STAT_Fame"            Header="Fame"                       Offset="2534" />
-<Column     Name="SKILL_Performance"    Header="Perform"                    Offset="2675" />
+<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Type="Numeric"   Header="Age"                        Offset="2252" />
+<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="2393" />
+<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="2534" />
+<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="2675" />
 </ListBox>
 </Screen>

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -43,9 +43,29 @@ struct cListItem
     std::vector<cSurface> m_PreRendered;
 };
 
+enum class ColumnType {
+                       String = 0, // also the fallback choice
+                       Numeric,
+                       Age,     // numeric, or '???'
+};
+
+inline
+ColumnType from_string(std::string const& str)
+{
+  if(str == "String")
+    return ColumnType::String;
+  else if(str == "Numeric")
+    return ColumnType::Numeric;
+  else if(str == "Age")
+    return ColumnType::Age;
+  else
+    return ColumnType{};
+}
+
 struct sColumnData {
     std::string name;           // internal name of the column
     std::string header;         // displayed header of the column
+    ColumnType type;            // type of the column (chooses sorting order)
     int offset = -1;            // draw offset
     int width = -1;             // width of the column
     int sort;                   // sorting index, in case display order does not correspond to internal data order.
@@ -106,7 +126,7 @@ public:
 
     std::string m_HeaderClicked;                    // set to m_ColumnName value of a header that has just been clicked; otherwise empty
 
-    void DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<int> offset, std::vector<bool> skip);  // define column layout
+    void DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<ColumnType> types, std::vector<int> offset, std::vector<bool> skip);  // define column layout
     void SetColumnSort(const std::vector<std::string>& column_name);    // Update column sorting based on expected default order
     void AddElement(int ID, std::vector<std::string> data, int color);
     void SetElementText(int ID, std::string data[], int columns);

--- a/src/engine/interface/cInterfaceWindowXML.cpp
+++ b/src/engine/interface/cInterfaceWindowXML.cpp
@@ -268,6 +268,7 @@ void cInterfaceWindowXML::read_listbox_definition(tinyxml2::XMLElement& el)
     std::vector<int> column_offset;
     std::vector<bool> column_skip;
     std::vector<std::string> column_name, column_header;
+    std::vector<ColumnType> column_type;
     for (auto& sub_el : IterateChildElements(el))
     {
         std::string tag = sub_el.Value();
@@ -279,8 +280,11 @@ void cInterfaceWindowXML::read_listbox_definition(tinyxml2::XMLElement& el)
             int offset = sub_el.IntAttribute("Offset", 0);
             bool skip = sub_el.BoolAttribute("Skip", false);
             std::string header = GetDefaultedStringAttribute(sub_el, "Header", name.c_str());
+            auto type = from_string(GetDefaultedStringAttribute(sub_el, "Type", "(default)"));
+
             column_name.push_back(std::move(name));
             column_header.push_back(std::move(header));
+            column_type.push_back(type);
             column_offset.push_back(offset);
             column_skip.push_back(skip);
         }
@@ -290,7 +294,9 @@ void cInterfaceWindowXML::read_listbox_definition(tinyxml2::XMLElement& el)
         }
     }
     // If we have columns defined, go ahead and give the listbox all the gory details
-    if (!column_name.empty())    box->DefineColumns(column_name, column_header, column_offset, column_skip);
+    if (!column_name.empty())
+      box->DefineColumns(column_name, column_header, column_type,
+                         column_offset, column_skip);
 }
 
 

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -861,72 +861,41 @@ namespace {
 
   enum class Direction { Ascending, Descending };
 
+  // Fetches the value of `item` at column `col_id`, and returns it as
+  // some type with an `operator<()` that gives us the sorting order
+  // we want.
   template<ColumnType>
-  void do_sort(cListBox::item_list_t& list, int col_id, Direction dir);
+  auto get_value(cListItem const& item, int col_id);
 
   template<>
-  void do_sort<ColumnType::Numeric>(cListBox::item_list_t& list, int col_id, Direction dir)
+  auto get_value<ColumnType::Numeric>(cListItem const& item, int col_id)
   {
-    auto get_value = [col_id](cListItem const& item) {
-		       return std::stoi(item.m_Data[col_id]);
-		     };
-
-    auto less_than = [get_value](cListItem const& a, cListItem const& b) {
-		       return get_value(a) < get_value(b);
-		     };
-
-    switch(dir) {
-    case Direction::Ascending:
-      list.sort([less_than](const cListItem& a, const cListItem& b) {
-		  return less_than(a, b);
-		});
-      break;
-    case Direction::Descending:
-      list.sort([less_than](const cListItem& a, const cListItem& b) {
-		  return less_than(b, a);
-		});
-      break;
-    }
+    return std::stoi(item.m_Data[col_id]);
   }
 
   template<>
-  void do_sort<ColumnType::Age>(cListBox::item_list_t& list, int col_id, Direction dir)
+  auto get_value<ColumnType::Age>(cListItem const& item, int col_id)
   {
-    auto get_value = [col_id](cListItem const& item) {
-		       if(item.m_Data[col_id] == "???")
-			 return std::numeric_limits<int>::max();
-		       else
-			 return std::stoi(item.m_Data[col_id]);
-		     };
-
-    auto less_than = [get_value](cListItem const& a, cListItem const& b) {
-		       return get_value(a) < get_value(b);
-		     };
-
-    switch(dir) {
-    case Direction::Ascending:
-      list.sort([less_than](const cListItem& a, const cListItem& b) {
-		  return less_than(a, b);
-		});
-      break;
-    case Direction::Descending:
-      list.sort([less_than](const cListItem& a, const cListItem& b) {
-		  return less_than(b, a);
-		});
-      break;
-    }
+    if(item.m_Data[col_id] == "???")
+      return std::numeric_limits<int>::max();
+    else
+      return std::stoi(item.m_Data[col_id]);
   }
 
   template<>
-  void do_sort<ColumnType::String>(cListBox::item_list_t& list, int col_id, Direction dir)
+  auto get_value<ColumnType::String>(cListItem const& item, int col_id)
   {
-    auto get_value = [col_id](cListItem const& item) {
-		       return item.m_Data[col_id];
-		     };
+    return item.m_Data[col_id];
+  }
 
-    auto less_than = [get_value](cListItem const& a, cListItem const& b) {
-		       return get_value(a).compare(get_value(b)) < 0;
-		     };
+  // Sorts `list` by column `col_id` of type `col_type`.
+  template<ColumnType col_type>
+  void do_sort(cListBox::item_list_t& list, int col_id, Direction dir)
+  {
+    auto less_than
+      = [col_id](cListItem const& a, cListItem const& b) {
+	  return get_value<col_type>(a, col_id) < get_value<col_type>(b, col_id);
+	};
 
     switch(dir) {
     case Direction::Ascending:

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -17,6 +17,8 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <algorithm>
+#include <map>
+
 #include <SDL_timer.h>              // needed to detect double clicks
 #include "utils/DirPath.h"
 #include "widgets/cListBox.h"
@@ -777,6 +779,170 @@ void cListBox::UnSortList()
     UpdatePositionsAfterSort();
 }
 
+namespace {
+  // No std::string::starts_with() until C++20. So here's a
+  // reimplementation.
+  bool starts_with(std::string const& str, std::string const& prefix)
+  {
+    return prefix.size() <= str.size()
+      && std::equal(prefix.begin(), prefix.end(), str.begin());
+  };
+
+  enum class ColumnType {
+			 Numeric,
+			 Age,	// numeric, or '???'
+			 String,
+  };
+
+  const std::map<std::string, ColumnType> column_types =
+    {
+     // The main girl management screen
+     {"Name", ColumnType::String},
+     {"Health", ColumnType::Numeric},
+     {"Happiness", ColumnType::Numeric},
+     {"Tiredness", ColumnType::Numeric},
+     {"DayJob", ColumnType::String},
+     {"NightJob", ColumnType::String},
+     {"is_pregnant", ColumnType::String},
+     {"is_slave", ColumnType::String},
+     {"Rebel", ColumnType::Numeric},
+     {"Age", ColumnType::Age},
+     {"Looks", ColumnType::Numeric},
+     {"SexAverage", ColumnType::Numeric},
+
+     // Centre
+     {"is_addict", ColumnType::String},
+
+     // Clinic
+     {"has_disease", ColumnType::String},
+
+     // Dungeon
+     {"Rebelliousness", ColumnType::Numeric},
+     {"Duration", ColumnType::Numeric},
+     {"Feeding", ColumnType::String},
+     {"Tortured", ColumnType::String},
+     {"Reason", ColumnType::String},
+
+     // House
+     {"SO", ColumnType::String},
+     {"SkillAverage", ColumnType::Numeric},
+
+     // Transfer screen
+     {"DayJobShort", ColumnType::String},
+     {"NightJobShort", ColumnType::String},
+
+     // Gangs screen
+     {"GangName", ColumnType::String},
+     {"Mission", ColumnType::String},
+     {"Number", ColumnType::Numeric},
+     {"Combat", ColumnType::Numeric},
+     {"Magic", ColumnType::Numeric},
+     {"Intelligence", ColumnType::Numeric},
+     {"Agility", ColumnType::Numeric},
+     {"Constitution", ColumnType::Numeric},
+     {"Strength", ColumnType::Numeric},
+     {"Service", ColumnType::Numeric},
+     {"Charisma", ColumnType::Numeric},
+    };
+
+  ColumnType find_column_type(std::string const& name)
+  {
+    // First look in the table
+    auto iter = column_types.find(name);
+    if(iter != column_types.end())
+      return iter->second;
+
+    // Then apply some heuristics
+    if(starts_with(name, "STAT_") || starts_with(name, "SKILL_"))
+      return ColumnType::Numeric; // Stats and skills are numeric.
+
+    return ColumnType::String;	// Say that it's a string
+  }
+
+  enum class Direction { Ascending, Descending };
+
+  template<ColumnType>
+  void do_sort(cListBox::item_list_t& list, int col_id, Direction dir);
+
+  template<>
+  void do_sort<ColumnType::Numeric>(cListBox::item_list_t& list, int col_id, Direction dir)
+  {
+    auto get_value = [col_id](cListItem const& item) {
+		       return std::stoi(item.m_Data[col_id]);
+		     };
+
+    auto less_than = [get_value](cListItem const& a, cListItem const& b) {
+		       return get_value(a) < get_value(b);
+		     };
+
+    switch(dir) {
+    case Direction::Ascending:
+      list.sort([less_than](const cListItem& a, const cListItem& b) {
+		  return less_than(a, b);
+		});
+      break;
+    case Direction::Descending:
+      list.sort([less_than](const cListItem& a, const cListItem& b) {
+		  return less_than(b, a);
+		});
+      break;
+    }
+  }
+
+  template<>
+  void do_sort<ColumnType::Age>(cListBox::item_list_t& list, int col_id, Direction dir)
+  {
+    auto get_value = [col_id](cListItem const& item) {
+		       if(item.m_Data[col_id] == "???")
+			 return std::numeric_limits<int>::max();
+		       else
+			 return std::stoi(item.m_Data[col_id]);
+		     };
+
+    auto less_than = [get_value](cListItem const& a, cListItem const& b) {
+		       return get_value(a) < get_value(b);
+		     };
+
+    switch(dir) {
+    case Direction::Ascending:
+      list.sort([less_than](const cListItem& a, const cListItem& b) {
+		  return less_than(a, b);
+		});
+      break;
+    case Direction::Descending:
+      list.sort([less_than](const cListItem& a, const cListItem& b) {
+		  return less_than(b, a);
+		});
+      break;
+    }
+  }
+
+  template<>
+  void do_sort<ColumnType::String>(cListBox::item_list_t& list, int col_id, Direction dir)
+  {
+    auto get_value = [col_id](cListItem const& item) {
+		       return item.m_Data[col_id];
+		     };
+
+    auto less_than = [get_value](cListItem const& a, cListItem const& b) {
+		       return get_value(a).compare(get_value(b)) < 0;
+		     };
+
+    switch(dir) {
+    case Direction::Ascending:
+      list.sort([less_than](const cListItem& a, const cListItem& b) {
+		  return less_than(a, b);
+		});
+      break;
+    case Direction::Descending:
+      list.sort([less_than](const cListItem& a, const cListItem& b) {
+		  return less_than(b, a);
+		});
+      break;
+    }
+  }
+}
+
 void cListBox::SortByColumn(std::string ColumnName, bool Descending)
 {
     if (m_Items.empty())  // any items in list?
@@ -796,11 +962,23 @@ void cListBox::SortByColumn(std::string ColumnName, bool Descending)
         return;
 
     // Sort the list
-    m_Items.sort([col_id, Descending](const cListItem& a, const cListItem& b) {
-        // TODO use a comparison function adequate for the column type
-        bool cmp = a.m_Data[col_id].compare(b.m_Data[col_id]) > 0;
-        return Descending == cmp;
-    });
+    //
+    // Note: std::list<>::sort() preserves all iterators; so
+    // `m_LastSelected` will effectively be carried along to the
+    // target element's new position.
+
+    auto direction = Descending ? Direction::Descending : Direction::Ascending;
+    switch(find_column_type(ColumnName)) {
+    case ColumnType::Numeric:
+      do_sort<ColumnType::Numeric>(m_Items, col_id, direction);
+      break;
+    case ColumnType::Age:
+      do_sort<ColumnType::Age>(m_Items, col_id, direction);
+      break;
+    case ColumnType::String:
+      do_sort<ColumnType::String>(m_Items, col_id, direction);
+      break;
+    }
 
     UpdatePositionsAfterSort();
 

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -1985,14 +1985,17 @@ void cJobManager::register_job(std::unique_ptr<IGenericJob> job) {
 }
 
 const IGenericJob* cJobManager::get_job(JOBS job) const {
-    if(job < 0 || job >= m_OOPJobs.size())
-      job = JOB_INDUNGEON;
+    if(job < 0 || job >= m_OOPJobs.size()) {
+      g_LogFile.error("jobmgr",
+		      "Job ", job, " is outside the (0..", m_OOPJobs.size(), "( range.");
+      throw std::out_of_range("cJobManager::get_job()");
+    }
 
     auto& ptr = m_OOPJobs[job];
     if(!ptr) {
-      // this one NEEDS to be non-null.
-      assert(m_OOPJobs[JOB_INDUNGEON].get() != nullptr);
-      return m_OOPJobs[JOB_INDUNGEON].get();
+      g_LogFile.error("jobmgr",
+		      "Job ", job, " has not been registered.");
+      throw std::invalid_argument("cJobManager::get_job()");
     }
 
     return ptr.get();

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -251,6 +251,7 @@ void cJobManager::do_custjobs(IBuilding& brothel, bool Day0Night1)
 
 bool cJobManager::FullTimeJob(JOBS Job)
 {
+    assert(m_OOPJobs.at(Job) != nullptr);
     return m_OOPJobs.at(Job)->get_info().FullTime;
 }
 
@@ -451,6 +452,7 @@ bool cJobManager::HandleSpecialJobs(sGirl& Girl, JOBS JobID, JOBS OldJobID, bool
     if(Girl.m_Building)
         rest = JOB_RESTING;
 
+    assert(m_OOPJobs[JobID] != nullptr);
     auto check = m_OOPJobs[JobID]->is_job_valid(Girl);
     if(!check) {
         g_Game->push_message(check.Reason, 0);
@@ -1868,6 +1870,7 @@ bool cJobManager::do_job(sGirl& girl, bool is_night)
 
 bool cJobManager::do_job(JOBS job_id, sGirl& girl, bool is_night)
 {
+    assert(m_OOPJobs[job_id] != nullptr);
     auto refused = m_OOPJobs[job_id]->Work(girl, is_night, g_Dice);
     if(is_night) {
         girl.m_Refused_To_Work_Night = refused;
@@ -1977,6 +1980,7 @@ void cJobManager::CatchGirl(sGirl& girl, std::stringstream& fuckMessage, const s
 }
 
 void cJobManager::register_job(std::unique_ptr<IGenericJob> job) {
+    assert(job != nullptr);
     m_OOPJobs[job->job()] = std::move(job);
 }
 
@@ -1985,14 +1989,17 @@ const IGenericJob* cJobManager::get_job(JOBS job) const {
 }
 
 const std::string& cJobManager::get_job_name(JOBS job) const {
+    assert(get_job(job) != nullptr);
     return get_job(job)->get_info().Name;
 }
 
 const std::string& cJobManager::get_job_brief(JOBS job) const {
+    assert(get_job(job) != nullptr);
     return get_job(job)->get_info().ShortName;
 }
 
 const std::string& cJobManager::get_job_description(JOBS job) const {
+    assert(get_job(job) != nullptr);
     return get_job(job)->get_info().Description;
 }
 

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -1985,7 +1985,17 @@ void cJobManager::register_job(std::unique_ptr<IGenericJob> job) {
 }
 
 const IGenericJob* cJobManager::get_job(JOBS job) const {
-    return m_OOPJobs.at(job).get();
+    if(job < 0 || job >= m_OOPJobs.size())
+      job = JOB_INDUNGEON;
+
+    auto& ptr = m_OOPJobs[job];
+    if(!ptr) {
+      // this one NEEDS to be non-null.
+      assert(m_OOPJobs[JOB_INDUNGEON].get() != nullptr);
+      return m_OOPJobs[JOB_INDUNGEON].get();
+    }
+
+    return ptr.get();
 }
 
 const std::string& cJobManager::get_job_name(JOBS job) const {

--- a/src/game/jobs/GenericJob.cpp
+++ b/src/game/jobs/GenericJob.cpp
@@ -182,6 +182,11 @@ DECL_JOB(SOBisexual);
 DECL_JOB(SOLesbian);
 DECL_JOB(FakeOrgasm);
 
+namespace {
+  bool WorkNullJob(sGirl&, bool, cRng&) { return false; }
+  double JP_NullJob(const sGirl&, bool) { return 0.0; }
+}
+
 #define REGISTER_JOB_MANUAL(J, Wf, Pf, Brief, Desc)                                     \
     [&]() -> auto& {                                                                    \
     auto new_job = std::make_unique<cJobWrapper>(J, Work##Wf, JP_##Pf, Brief, Desc);    \
@@ -267,6 +272,10 @@ void RegisterWrappedJobs(cJobManager& mgr) {
     REGISTER_JOB(JOB_SO_BISEXUAL, SOBisexual, "SOBi", "You will make sure she likes having sex with both men and women.").full_time();
     REGISTER_JOB(JOB_SO_LESBIAN, SOLesbian, "SOLe", "You will make sure she only likes having sex with women.").full_time();
     REGISTER_JOB(JOB_FAKEORGASM, FakeOrgasm, "FOEx", "You will teach her how to fake her orgasms.").full_time();
+
+    // Some pseudo-jobs
+    REGISTER_JOB(JOB_INDUNGEON, NullJob, "", "She is languishing in the dungeon.");
+    REGISTER_JOB(JOB_RUNAWAY, NullJob, "", "She has escaped.");
 }
 
 double cBasicJob::GetPerformance(const sGirl& girl, bool estimate) const {


### PR DESCRIPTION
I implemented the per-column type sorting (because "1, 10, 100, 11, 18, 2, 3, 45" tires quickly). It shouldn't be too hard to extend to more types if needed.

Ideally, the sorter should work directly with the underlying values instead of parsing them out of the formatted strings -- but this is at least a step in the right direction.

(And it seems that my mis-merge lives on. I think it'll live until I take down and then re-clone my repository.)