### PR TITLE
Tilde expanding file paths

### DIFF
--- a/src/engine/include/utils/DirPath.h
+++ b/src/engine/include/utils/DirPath.h
@@ -87,6 +87,10 @@ public:
     operator std::string()    { return path; }
 
     bool is_directory() const;
+
+    // Expands environment variables (not yet) and the tilde syntax for
+    // home directories (Unix only).
+    static std::string expand_path(std::string path);
 };
 
 inline std::ostream& operator<<(std::ostream& target, const DirPath& content) {

--- a/src/engine/utils/DirPath.cpp
+++ b/src/engine/utils/DirPath.cpp
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include "boost/optional.hpp"
 #include "utils/DirPath.h"
 #include "CLog.h"
 
@@ -76,7 +78,7 @@ namespace {
 
   // look up my current home directory in /etc/passwd (or NIS or
   // wherever).
-  std::unique_ptr<std::string> find_pwd_home()
+  boost::optional<std::string> find_pwd_home()
   {
     size_t bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
     if(bufsize == static_cast<size_t>(-1))
@@ -97,7 +99,7 @@ namespace {
 	return {};
       }
 
-    return std::make_unique<std::string>(pwd.pw_dir);
+    return boost::make_optional<std::string>(pwd.pw_dir);
   }
 
   // Expand "~/some/dir" to "<my home-dir>/some/dir"

--- a/src/engine/utils/DirPath.cpp
+++ b/src/engine/utils/DirPath.cpp
@@ -26,6 +26,11 @@
 #include <dirent.h>
 #include <cerrno>
 #include <cstring>
+#include <cstdlib>
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
 
 const char    DirPath::sep[] = "/";
 
@@ -64,4 +69,61 @@ ButtonPath::ButtonPath(const std::string& filename)
         : DirPath()
 {
     (*this) << "Resources" << "Buttons" << filename;
+}
+
+namespace {
+#if defined(LINUX)
+
+  // look up my current home directory in /etc/passwd (or NIS or
+  // wherever).
+  std::unique_ptr<std::string> find_pwd_home()
+  {
+    size_t bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if(bufsize == static_cast<size_t>(-1))
+      bufsize = 16384;		// Should be big enough
+
+    struct passwd pwd;
+    std::vector<char> buf(bufsize);
+    struct passwd* result;
+
+    auto err = getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result);
+    if(!result)
+      {
+	if(err == 0)
+	  g_LogFile.warning("io", "User has no home directory.");
+	else
+	  g_LogFile.error("io", "getpwuid_r() failed: ", std::strerror(err), " (", err, ")");
+
+	return {};
+      }
+
+    return std::make_unique<std::string>(pwd.pw_dir);
+  }
+
+  // Expand "~/some/dir" to "<my home-dir>/some/dir"
+  //
+  // TODO: Expand "~mike/dir" to "<mike's home-dir>/dir"
+  std::string tildeexpand(std::string path)
+  {
+    if(path.empty())
+      return path;
+
+    if(path.substr(0, 2) == "~/")
+      if(auto env_home = std::getenv("HOME"))
+	return path.replace(0, 1, env_home);
+      else if(auto pwd_home = find_pwd_home())
+	return path.replace(0, 1, *pwd_home);
+
+    return path;
+  }
+#endif
+}
+
+std::string DirPath::expand_path(std::string path)
+{
+#if defined(LINUX)
+  return tildeexpand(std::move(path));
+#else
+  return path;
+#endif
 }

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -1076,11 +1076,11 @@ void Game::NewGame(const std::function<void(std::string)>& callback) {
 
     callback("Loading Items");
     g_LogFile.info("prepare", "Loading Items");
-    LoadItemFiles(cfg.folders.items().c_str());
+    LoadItemFiles(DirPath::expand_path(cfg.folders.items()).c_str());
 
     callback("Loading Girls");
     g_LogFile.info("prepare", "Loading Girl Files");
-    LoadGirlFiles(cfg.folders.characters().c_str(), callback);
+    LoadGirlFiles(DirPath::expand_path(cfg.folders.characters()).c_str(), callback);
 
     g_LogFile.info("prepare", "Update Shop");
     m_Shop->RestockShop();
@@ -1103,7 +1103,7 @@ void Game::LoadGame(const tinyxml2::XMLElement& source, const std::function<void
 
     callback("Loading Items");
     g_LogFile.info("prepare", "Loading Items");
-    LoadItemFiles(cfg.folders.items().c_str());
+    LoadItemFiles(DirPath::expand_path(cfg.folders.items()).c_str());
 
     // girl file list
     g_LogFile.info("prepare", "Loading Girl List");
@@ -1116,7 +1116,7 @@ void Game::LoadGame(const tinyxml2::XMLElement& source, const std::function<void
 
     callback("Loading Girl Files");
     g_LogFile.info("prepare", "Loading Girl Files");
-    LoadGirlFiles(cfg.folders.characters().c_str(), callback);
+    LoadGirlFiles(DirPath::expand_path(cfg.folders.characters()).c_str(), callback);
 
     g_LogFile.log(ELogLevel::INFO, "Loading Rivals");
     callback("Loading Rivals");

--- a/src/game/InterfaceProcesses.cpp
+++ b/src/game/InterfaceProcesses.cpp
@@ -97,7 +97,7 @@ void NextWeek()
 
 void AutoSaveGame()
 {
-    SaveGameXML(DirPath(cfg.folders.saves().c_str()) << "autosave.gam");
+    SaveGameXML(DirPath(DirPath::expand_path(cfg.folders.saves()).c_str()) << "autosave.gam");
 }
 
 void SaveGame()
@@ -105,7 +105,7 @@ void SaveGame()
     std::string filename = g_Game->buildings().get_building(0).name();
     std::string filenamedotgam = filename + ".gam";
 
-    SaveGameXML(DirPath(cfg.folders.saves().c_str()) << filenamedotgam);
+    SaveGameXML(DirPath(DirPath::expand_path(cfg.folders.saves()).c_str()) << filenamedotgam);
     if (cfg.folders.backupsaves())
     {
         SaveGameXML(DirPath() << "Saves" << filenamedotgam);

--- a/src/game/screens/cGameWindow.cpp
+++ b/src/game/screens/cGameWindow.cpp
@@ -1043,7 +1043,7 @@ std::vector<std::string> FindImage(const sGirl& girl, int imagetype, bool galler
     g_LogFile.log(ELogLevel::DEBUG, "Debug Alt Images || Getting image for: ", girl.FullName(), " (", image_folder, ")");
 
     int dir = 0; DirPath usedir = "";
-    DirPath imagedirDc = DirPath(cfg.folders.defaultimageloc().c_str());        // usedir = -1
+    DirPath imagedirDc = DirPath(DirPath::expand_path(cfg.folders.defaultimageloc()).c_str());        // usedir = -1
     DirPath imagedirDo = DirPath() << "Resources" << "DefaultImages";            // usedir = -2
     FileList tiCc(image_folder, "*.*");
     FileList tiDc(imagedirDc, "*.*");

--- a/src/game/screens/cScreenLoadGame.cpp
+++ b/src/game/screens/cScreenLoadGame.cpp
@@ -27,7 +27,7 @@ extern int g_ReturnInt;
 
 cScreenLoadGame::cScreenLoadGame(const std::string& save_folder) :
     cInterfaceWindowXML("LoadMenu.xml"),
-    m_SavesPath(save_folder.c_str())
+    m_SavesPath(DirPath::expand_path(save_folder).c_str())
 {
 }
 

--- a/src/game/screens/cScreenMainMenu.cpp
+++ b/src/game/screens/cScreenMainMenu.cpp
@@ -57,7 +57,7 @@ void cScreenMainMenu::set_ids()
 
 cScreenMainMenu::cScreenMainMenu(std::string saves_path) :
     cInterfaceWindowXML("main_menu.xml"),
-    m_SaveGamesPath(std::move(saves_path))
+    m_SaveGamesPath(DirPath::expand_path(std::move(saves_path)))
 {
 }
 


### PR DESCRIPTION
As a Unix/Linux guy I expect that `~/` expands to my home directory (`/mnt/usr/u/home/use-after-free/`), and that I can have my gamesaves in `~/.saves/WM` and girl files in `~/WM-girls`.