### PR TITLE
Improves cInventory::GetRandomItem() and simplifies callers.

### DIFF
--- a/src/game/cInventory.cpp
+++ b/src/game/cInventory.cpp
@@ -31,6 +31,8 @@
 #include "xml/getattr.h"
 #include "Inventory.h"
 
+#include "utils/algorithms.hpp"
+
 using namespace std;
 
 namespace settings {
@@ -179,48 +181,7 @@ ostream& operator<<(ostream& os, sEffect& eff) {
 // Deletes all nulls from `items`.
 void cInventory::cull_null_items(std::vector<sInventoryItem *>& items)
 {
-   items.erase(
-      std::remove_if(begin(items), end(items),
-                     [](auto* ptr) {return ptr == nullptr;}),
-      end(items));
-}
-
-// ----- Get
-//
-// Returns a random non-null item from `items`; if `items` is empty,
-// null is returned. May choose to clean out null items from `items`.
-//
-// Note: Will not spuriously return `nullptr`.
-sInventoryItem*
-cInventory::GetRandomItem_from(std::vector<sInventoryItem *>& items)
-{
-   auto find_item
-      = [](std::vector<sInventoryItem *> const& items) -> sInventoryItem* {
-           switch(items.size())
-           {
-              case 0:
-                 return nullptr;
-
-              case 1:
-                 return items[0];
-
-              default:
-                 return items[g_Dice % (items.size() - 1)];
-           }
-        };
-
-   if(auto* ptr = find_item(items))
-      return ptr;
-   else
-   {                       // bad luck; clean out any nulls and retry
-      cull_null_items(items);
-      assert(std::none_of(begin(items), end(items),
-                          [](auto* ptr) {return ptr == nullptr;})
-             && "no nulls in `items`.");
-
-      // if we're truly empty then we return `nullptr`
-      return find_item(items);
-   }
+   erase_if(items, [](auto* ptr) {return ptr == nullptr;});
 }
 
 sInventoryItem* cInventory::GetRandomCatacombItem()

--- a/src/game/cObjectiveManager.cpp
+++ b/src/game/cObjectiveManager.cpp
@@ -431,7 +431,9 @@ void cObjectiveManager::PassObjective()
             {
                 tries--;
                 sInventoryItem* item = g_Game->inventory_manager().GetRandomItem();
-                if (item && item->m_Rarity < RARITYSCRIPTONLY)
+                if(!item)
+                   break;       // supplier is all out :(
+                else if (item->m_Rarity < RARITYSCRIPTONLY)
                 {
                     if(g_Game->player().inventory().add_item(item)) {
                         itemnames.push_back(item->m_Name);

--- a/src/game/cRival.cpp
+++ b/src/game/cRival.cpp
@@ -585,11 +585,16 @@ void cRivalManager::Update(int& NumPlayerBussiness)
                     int items = 0;
                     while (g_Dice.percent(60) && items <= (cG1.m_Num / 3) && curr->m_NumInventory < MAXNUM_RIVAL_INVENTORY)
                     {
-                        bool add = false;
-                        sInventoryItem* temp;
-                        do { temp = g_Game->inventory_manager().GetRandomItem();
-                        } while (!temp || temp->m_Rarity < RARITYSHOP25 || temp->m_Rarity > RARITYCATACOMB01);
+                        auto filter
+                           = [](sInventoryItem const& item){
+                                return item.m_Rarity >= RARITYSHOP25
+                                   && item.m_Rarity <= RARITYCATACOMB01;
+                             };
 
+                        sInventoryItem* temp
+                           = g_Game->inventory_manager().GetRandomItem(filter);
+
+                        bool add = false;
                         switch (temp->m_Rarity)
                         {
                         case RARITYSHOP25:                                add = true;        break;

--- a/src/game/cShop.cpp
+++ b/src/game/cShop.cpp
@@ -136,8 +136,8 @@ void cShop::RestockShop() {
     // fill up again
     while(m_Inventory.all_items().size() < m_Capacity) {
         // find a random item
-        sInventoryItem* item = nullptr;
-        while (item == nullptr) item = g_Game->inventory_manager().GetRandomItem();
+        sInventoryItem* item = g_Game->inventory_manager().GetRandomItem();
+        if(!item) break;        // supplier is all out :(
 
         // check spawn chance
         int chance = g_Dice.d100();

--- a/src/game/scripting/cLuaScript.cpp
+++ b/src/game/scripting/cLuaScript.cpp
@@ -229,18 +229,16 @@ int cLuaScript::GameOver(lua_State* state) {
 }
 
 int cLuaScript::GivePlayerRandomSpecialItem(lua_State* state) {
-    sInventoryItem* item = g_Game->inventory_manager().GetRandomItem();
-    while (item == nullptr)
-        item = g_Game->inventory_manager().GetRandomItem();
+    auto filter
+       = [](sInventoryItem const& item){
+            return item.m_Rarity >= RARITYSHOP05;
+         };
 
-    bool ok = false;
-    while (!ok)
+    sInventoryItem* item = g_Game->inventory_manager().GetRandomItem(filter);
+    if(!item)
     {
-        if (item->m_Rarity >= RARITYSHOP05) ok = true;
-        else
-        {
-            do { item = g_Game->inventory_manager().GetRandomItem(); } while (item == nullptr);
-        }
+       g_Game->push_message(" There are no suitable items to be had\n", COLOR_RED);
+       return 0;
     }
 
     if(!g_Game->player().inventory().add_item(item)) {


### PR DESCRIPTION
Here I fix a bug where a bad item directory made the game lock up when refilling the shop (and in other situations). Here's what happened to me:

1. The bad item directory leaves the item vector (`m_Items`) empty.
2. This made `GetRandomItem()` consistently return null.
3. Callers misunderstood that null as "bad luck, try again"...
4. ...so they did. Forever.

(I reckon this empty item vector to be the rare case, so any early check for it would be _mostly_ useless. Instead I let it make their way down to `GetRandomItem_from()` and the `find_item` lambda that has to handle it anyway.)