### PR TITLE
Modernizing the rng.

### DIFF
--- a/src/engine/cRng.cpp
+++ b/src/engine/cRng.cpp
@@ -18,6 +18,11 @@
  */
 #include"cRng.h"
 #include <ctime>
+#include <array>
+#include <iostream>
+#include <iomanip>
+
+#include "doctest.h"
 
 /*
  * easier to use the method internally than an operator
@@ -89,3 +94,192 @@ const char* cRng::select_text(std::initializer_list<const char*> options) {
 }
 
 //end mod
+
+TEST_CASE("random(int) statistics 1"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 20;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 1> bins = {};
+
+   cRng rng;
+
+   std::cout << "random(" << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.random(n_bins)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("random(int) statistics 2"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 19;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 1> bins = {};
+
+   cRng rng;
+
+   std::cout << "random(" << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.random(n_bins)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("operator%() statistics 1"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 20;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 1> bins = {};
+
+   cRng rng;
+
+   std::cout << "operator%(" << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng % n_bins]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("operator%() statistics 2"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 19;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 1> bins = {};
+
+   cRng rng;
+
+   std::cout << "operator%(" << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng % n_bins]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("in_range() statistics 1"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 20;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 1> bins = {};
+
+   cRng rng;
+
+   std::cout << "in_range(0, " << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.in_range(0, n_bins)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("in_range() statistics 2"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 19;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 1> bins = {};
+
+   cRng rng;
+
+   std::cout << "in_range(0, " << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.in_range(0, n_bins)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("in_range() statistics 3"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 19;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 2> bins = {};
+
+   cRng rng;
+
+   std::cout << "in_range(1, " << n_bins+1 << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.in_range(1, n_bins+1)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("bell() statistics 1"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 20;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 2> bins = {};
+
+   cRng rng;
+
+   std::cout << "bell(0, " << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.bell(0, n_bins)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}
+
+TEST_CASE("bell() statistics 2"
+          * doctest::skip(true))
+{
+   constexpr const size_t n_bins = 19;
+   constexpr const size_t fill_factor = 10'000'000;
+
+   std::array<size_t, n_bins + 2> bins = {};
+
+   cRng rng;
+
+   std::cout << "bell(0, " << n_bins << ") statistics:\n"
+             << "  fill factor is " << fill_factor << " samples per bin\n";
+
+   for(size_t i = 0; i < n_bins * fill_factor; ++i)
+      bins[rng.bell(0, n_bins)]++;
+
+   for(size_t i = 0; i < bins.size(); ++i)
+      std::cout << std::right << std::setw(2) << i << ": "
+                << std::setw(8) << bins[i] << std::setw(0) << '\n';
+}

--- a/src/engine/include/cRng.h
+++ b/src/engine/include/cRng.h
@@ -71,12 +71,7 @@ struct cRng
 */
     int bell(int min, int max, int mid);
     int bell(int min, int max);
-/*
- *    I was thinking of this as useful shorthand for all the
- *    (g_Dice % 100)+1 lines, but on reflection, I think 
- *    I prefer the function following
- */
-    int operator +(int n) { return random(100) + n; }
+
 /*
  *    returns true n percent of the time. 
  *    so g_Dice.percent(20) will return true 20% of the time

--- a/src/engine/include/cRng.h
+++ b/src/engine/include/cRng.h
@@ -32,14 +32,23 @@ struct cRng
  *    because it's easier to build other funcs around a
  *    function than an operator. Well, less messy, anyway.
  */
-    int random(int n); // returns int between 0 and n
-    double randomd(double n); // returns double between 0 and n - `J` added
+
+    /// Returns a random integer `x` within `0 <= x < n`.
+    ///
+    /// All integers within the interval has the same probability.
+
+    // @{
+    int random(int n);
+
     /*
  *    modulus operator re-implemented using random()
  */
     int operator %(int n) {
         return  random(n);
     }
+    // @}
+
+    double randomd(double n); // returns double between 0 and n - `J` added
 /*
  *    returns a number randomly distributed between
  *    min and max.
@@ -47,6 +56,14 @@ struct cRng
  *    if min > max, then returns number in the range 0 to 100
  *    in order to replicate how the girl stat generation works
  */
+
+    /// Returns a random integer `x` within `min <= x < max`.
+    ///
+    /// All integers within the interval has the same probability.
+    ///
+    /// Note: If `min > max` then the interval `0 <= x < range` is
+    /// used instead. This replicates the girl stat generation
+    /// algorithm.
     int in_range(int min, int max, int range=101);
 
 /*
@@ -64,17 +81,25 @@ struct cRng
  *    returns true n percent of the time. 
  *    so g_Dice.percent(20) will return true 20% of the time
  */
-    bool percent(int n) { return random(100) < n; }
+
+    /// Returns `true` with a probability `p/100` (or `p` percents).
+
+    // @{
+    bool percent(int p) { return random(100) < p; }
     bool percent(sPercent p) { return percent(100.f * p); }
 /*
 *    `J` added percent allowing double input up to 3 decimal
 *    returns true n percent of the time.
 *    so g_Dice.percent(20.005) will return true 20.005% of the time
 */
-    bool percent(double n) { return (1 + random(100000)) < (n * 1000.0); }
+    bool percent(double p) { return (1 + random(100000)) < (p * 1000.0); }
+    // @}
 /*
  *    we generate d100 rolls a lot
  */
+    /// Simulates a d100 die.
+    ///
+    /// The returned random integer `x` is within `1 <= x <= 100`.
     int d100() { return random(100) + 1; }
 /*
  *    constructor and destructor
@@ -82,7 +107,7 @@ struct cRng
     cRng();
     ~cRng() = default;
 
-
+    /// Chooses one string to return, with equal probability.
     const char* select_text(std::initializer_list<const char*> options);
 };
 


### PR DESCRIPTION
I've added statistical tests to cRng to understand more precisely how the generator works.

* `random()`, `operator%()`, and `in_range()` all pick their numbers from a half-open interval `lo <= x < hi`; I've seen call sites that believe that `x == hi` can happen, and compensate for that. Those call sites should be reviewed at some point.

* `bell()` is weird. The distribution is triangular, not bell-shaped, and it uses an odd/even rule to decide between `lo <= x < hi` and `lo <= x <= hi`.