### PR TITLE
Gets the config file from the command line.

### DIFF
--- a/src/engine/include/sConfig.h
+++ b/src/engine/include/sConfig.h
@@ -25,7 +25,7 @@ struct sConfigData;
 
 class cConfig
 {
-    static    sConfigData    *data;
+    static std::unique_ptr<sConfigData> data;
 public:
     cConfig();
 
@@ -55,5 +55,7 @@ public:
     void set_value(const char* id, bool value);
 
     void save();
+
+    void reload(std::string const& filename = "config.xml");
 };
 

--- a/src/engine/sConfig.cpp
+++ b/src/engine/sConfig.cpp
@@ -31,14 +31,19 @@ struct sConfigData : public cSimpleKeyValue
     void load(const DirPath& source);
 };
 
-sConfigData *cConfig::data;
+std::unique_ptr<sConfigData> cConfig::data;
 
 cConfig::cConfig()
 {
     if (!data)
     {
-        data = new sConfigData();
+        data = std::make_unique<sConfigData>();
     }
+}
+
+void cConfig::reload(std::string const& filename)
+{
+   data = std::make_unique<sConfigData>(filename.c_str());
 }
 
 void cConfig::set_value(const char* id, std::string value) {

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -30,6 +30,8 @@
 #include <sstream>
 #include <SDL_events.h>
 
+#include "utils/DirPath.h"
+
 #define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
 
@@ -62,6 +64,15 @@ cNameList g_SurnameList;
 
 int main(int ac, char* av[])    // `J` Bookmark - #1 - Entering the game
 {
+    // Primitive option parsing goes here.
+    //
+    // TODO: Switch to something less painful, like
+    // Boost.Program_options or GNU getopt.
+    {
+       if(ac == 3 && strcmp("--config", av[1]) == 0)
+          cfg.reload(DirPath::expand_path(av[2]));
+    }
+
     bool running = true;
 
     // Init the program


### PR DESCRIPTION
Now you can say '--config ~/my-config.xml' to choose an alternate config file.

The command line parsing should ideally be done by a real parser, but the obvious one (Boost.Program_options) isn't header-only, and I'm not  sure if the other obvious one (getopt) can be built on Windows -- but I wouldn't mind trying.
