### PR TITLE
Table types

### DIFF
--- a/Resources/Interface/J_1024x768/arena_management_screen.xml
+++ b/Resources/Interface/J_1024x768/arena_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="150" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1024x768/centre_management_screen.xml
+++ b/Resources/Interface/J_1024x768/centre_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"          Type="String"        Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"       Header="Health"                     Offset="150" /> 
+<Column     Name="Health"        Type="Health"        Header="Health"                     Offset="150" />
 <Column     Name="Happiness"     Type="Numeric"       Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"     Type="Numeric"       Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"        Type="String"        Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1024x768/clinic_management_screen.xml
+++ b/Resources/Interface/J_1024x768/clinic_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="150" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1024x768/dungeon_screen.xml
+++ b/Resources/Interface/J_1024x768/dungeon_screen.xml
@@ -20,7 +20,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="632"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
-<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="150"  />
+<Column     Name="Health"         Type="Health"      Header="Health"                     Offset="150"  />
 <Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="187"  />
 <Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="224"  />
 <Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="261"  />

--- a/Resources/Interface/J_1024x768/farm_management_screen.xml
+++ b/Resources/Interface/J_1024x768/farm_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="150" /> 
+<Column     Name="Health"               Type="Health"  Header="Health"                     Offset="150" />
 <Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1024x768/girl_management_screen.xml
+++ b/Resources/Interface/J_1024x768/girl_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="150" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1024x768/house_management_screen.xml
+++ b/Resources/Interface/J_1024x768/house_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="150" /> 
+<Column     Name="Health"       Type="Health"         Header="Health"                     Offset="150" />
 <Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1024x768/studio_management_screen.xml
+++ b/Resources/Interface/J_1024x768/studio_management_screen.xml
@@ -22,7 +22,7 @@
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="862"     YPos="650"      Width="120"     Height="32"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="150" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="150" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="187" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="224" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="261" />

--- a/Resources/Interface/J_1366x768/arena_management_screen.xml
+++ b/Resources/Interface/J_1366x768/arena_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="200" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1366x768/centre_management_screen.xml
+++ b/Resources/Interface/J_1366x768/centre_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="200" /> 
+<Column     Name="Health"        Type="Health"         Header="Health"                     Offset="200" />
 <Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1366x768/clinic_management_screen.xml
+++ b/Resources/Interface/J_1366x768/clinic_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="200" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1366x768/farm_management_screen.xml
+++ b/Resources/Interface/J_1366x768/farm_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="200" /> 
+<Column     Name="Health"               Type="Health"  Header="Health"                     Offset="200" />
 <Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1366x768/girl_management_screen.xml
+++ b/Resources/Interface/J_1366x768/girl_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="200" /> 
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1366x768/house_management_screen.xml
+++ b/Resources/Interface/J_1366x768/house_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="200" /> 
+<Column     Name="Health"       Type="Health"        Header="Health"                     Offset="200" />
 <Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1366x768/studio_management_screen.xml
+++ b/Resources/Interface/J_1366x768/studio_management_screen.xml
@@ -22,7 +22,7 @@
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1150"     YPos="650"      Width="160"     Height="32"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="200" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="200" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="250" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="300" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="350" />

--- a/Resources/Interface/J_1600x900/arena_management_screen.xml
+++ b/Resources/Interface/J_1600x900/arena_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="234" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1600x900/centre_management_screen.xml
+++ b/Resources/Interface/J_1600x900/centre_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="234" /> 
+<Column     Name="Health"        Type="Health"        Header="Health"                     Offset="234" />
 <Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1600x900/clinic_management_screen.xml
+++ b/Resources/Interface/J_1600x900/clinic_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="234" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1600x900/farm_management_screen.xml
+++ b/Resources/Interface/J_1600x900/farm_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="234" /> 
+<Column     Name="Health"               Type="Health"  Header="Health"                     Offset="234" />
 <Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1600x900/girl_management_screen.xml
+++ b/Resources/Interface/J_1600x900/girl_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="234" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1600x900/house_management_screen.xml
+++ b/Resources/Interface/J_1600x900/house_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="234" /> 
+<Column     Name="Health"       Type="Health"         Header="Health"                     Offset="234" />
 <Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1600x900/studio_management_screen.xml
+++ b/Resources/Interface/J_1600x900/studio_management_screen.xml
@@ -22,7 +22,7 @@
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1347"     YPos="762"      Width="187"     Height="38"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="234" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="234" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="293" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="352" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="411" />

--- a/Resources/Interface/J_1920x1080/arena_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/arena_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="281" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_1920x1080/centre_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/centre_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="281" /> 
+<Column     Name="Health"        Type="Health"         Header="Health"                     Offset="281" />
 <Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_1920x1080/clinic_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/clinic_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="281" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_1920x1080/farm_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/farm_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="281" /> 
+<Column     Name="Health"               Type="Health"  Header="Health"                     Offset="281" />
 <Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_1920x1080/girl_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/girl_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="281" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_1920x1080/house_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/house_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="281" /> 
+<Column     Name="Health"       Type="Health"         Header="Health"                     Offset="281" />
 <Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_1920x1080/studio_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/studio_management_screen.xml
@@ -22,7 +22,7 @@
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1616"     YPos="914"      Width="225"     Height="45"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="281" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="281" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="351" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="421" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="491" />

--- a/Resources/Interface/J_3840x2160/arena_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/arena_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="562" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />

--- a/Resources/Interface/J_3840x2160/centre_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/centre_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="562" /> 
+<Column     Name="Health"        Type="Health"        Header="Health"                     Offset="562" />
 <Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="985" />

--- a/Resources/Interface/J_3840x2160/clinic_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/clinic_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="562" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />

--- a/Resources/Interface/J_3840x2160/farm_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/farm_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="562" /> 
+<Column     Name="Health"               Type="Health"  Header="Health"                     Offset="562" />
 <Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="985" />

--- a/Resources/Interface/J_3840x2160/girl_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/girl_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="562" /> 
+<Column     Name="Health"            Type="Health"     Header="Health"                     Offset="562" />
 <Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="985" />

--- a/Resources/Interface/J_3840x2160/house_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/house_management_screen.xml
@@ -22,7 +22,7 @@
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="562" /> 
+<Column     Name="Health"       Type="Health"         Header="Health"                     Offset="562" />
 <Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="985" />

--- a/Resources/Interface/J_3840x2160/studio_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/studio_management_screen.xml
@@ -22,7 +22,7 @@
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="3233"     YPos="1828"      Width="450"     Height="90"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
 <Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
+<Column     Name="Health"            Type="Health"    Header="Health"                     Offset="562" />
 <Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
 <Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
 <Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -62,6 +62,17 @@ ColumnType from_string(std::string const& str)
     return ColumnType{};
 }
 
+inline
+std::string to_string(ColumnType type)
+{
+   switch(type) {
+      case ColumnType::String:  return "String";
+      case ColumnType::Numeric: return "Numeric";
+      case ColumnType::Age:     return "Age";
+      default:                  return "(?)";
+   };
+}
+
 struct sColumnData {
     std::string name;           // internal name of the column
     std::string header;         // displayed header of the column

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -47,6 +47,7 @@ enum class ColumnType {
                        String = 0, // also the fallback choice
                        Numeric,
                        Age,     // numeric, or '???'
+                       Health,  // 'DEAD', or numeric.
 };
 
 inline
@@ -58,6 +59,8 @@ ColumnType from_string(std::string const& str)
     return ColumnType::Numeric;
   else if(str == "Age")
     return ColumnType::Age;
+  else if(str == "Health")
+    return ColumnType::Health;
   else
     return ColumnType{};
 }
@@ -69,6 +72,7 @@ std::string to_string(ColumnType type)
       case ColumnType::String:  return "String";
       case ColumnType::Numeric: return "Numeric";
       case ColumnType::Age:     return "Age";
+      case ColumnType::Health:  return "Health";
       default:                  return "(?)";
    };
 }

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -28,6 +28,7 @@
 #include "cScrollBar.h"
 #include "interface/cWindowManager.h"
 #include "interface/cInterfaceWindow.h"
+#include "CLog.h"
 
 extern sColor g_ListBoxBorderColor;
 extern sColor g_ListBoxBackgroundColor;
@@ -823,13 +824,13 @@ namespace {
     switch(dir) {
     case Direction::Ascending:
       list.sort([less_than](const cListItem& a, const cListItem& b) {
-		  return less_than(a, b);
-		});
+                 return less_than(a, b);
+               });
       break;
     case Direction::Descending:
       list.sort([less_than](const cListItem& a, const cListItem& b) {
-		  return less_than(b, a);
-		});
+                 return less_than(b, a);
+               });
       break;
     }
   }
@@ -874,7 +875,16 @@ void cListBox::SortByColumn(std::string ColumnName, bool Descending)
                 break;
         }
     } catch (const std::exception& error) {
-        window_manager().PushError(std::string("Error during sorting: ") + error.what());
+       g_LogFile.error("game", "Cannot sort on column '", ColumnName, "' of type ", to_string(m_Columns[col_ref].type), ".");
+#if defined(NDEBUG)
+       // Release build -- early out, leave the sort incomplete.
+       return;
+#else
+       // Debug build -- crash and dump core.
+       //
+       // FIXME: And what to do on Windows?
+       std::abort();
+#endif
     }
 
     UpdatePositionsAfterSort();

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -807,6 +807,15 @@ namespace {
   }
 
   template<>
+  auto get_value<ColumnType::Health>(cListItem const& item, int col_id)
+  {
+    if(item.m_Data[col_id] == "DEAD")
+      return std::numeric_limits<int>::min();
+    else
+      return std::stoi(item.m_Data[col_id]);
+  }
+
+  template<>
   auto get_value<ColumnType::String>(cListItem const& item, int col_id)
   {
     return item.m_Data[col_id];
@@ -869,6 +878,9 @@ void cListBox::SortByColumn(std::string ColumnName, bool Descending)
                 break;
             case ColumnType::Age:
                 do_sort<ColumnType::Age>(m_Items, col_id, direction);
+                break;
+            case ColumnType::Health:
+                do_sort<ColumnType::Health>(m_Items, col_id, direction);
                 break;
             case ColumnType::String:
                 do_sort<ColumnType::String>(m_Items, col_id, direction);


### PR DESCRIPTION
This PR fixes my notes 1a (crash in debug), 1b (early-out in release) and 2 (properly parse Health) in #26 . It does not fix the "is actually an Age" column problem you spotted (which column would that be?).

Now, recovering lost data by parsing display text isn't really the smartest thing to do; I'd rather not lose it in the first place -- one way would be by adding a `boost::variant<>` to the table cells. That, I think, would move the typedness from the columns to the individual cells, and we could also get rid if the explicit types that I added. This would also implicitly fix the "actually an Age" column.
