### PR TITLE
Use variant<> for list box data

### DIFF
--- a/Resources/Interface/J_1024x768/arena_management_screen.xml
+++ b/Resources/Interface/J_1024x768/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="559" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="596" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="633" />
-<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="670" />
-<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="707" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="150" />
+<Column     Name="Happiness"         Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Header="Age"                        Offset="596" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="633" />
+<Column     Name="SKILL_Magic"       Header="Magic"                      Offset="670" />
+<Column     Name="SKILL_Combat"      Header="Combat"                     Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/centre_management_screen.xml
+++ b/Resources/Interface/J_1024x768/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"          Type="String"        Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"       Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"     Type="Numeric"       Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"     Type="Numeric"       Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"        Type="String"        Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"      Type="String"        Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"   Type="String"        Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"      Type="String"        Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"         Type="Numeric"       Header="Rebel"                      Offset="559" />
-<Column     Name="Age"           Type="Age"           Header="Age"                        Offset="596" />
-<Column     Name="is_addict"     Type="String"        Header="Addict"                     Offset="633" />
-<Column     Name="SKILL_Service" Type="Numeric"       Header="Service"                    Offset="670" />
-<Column     Name="STAT_Charisma" Type="Numeric"       Header="Charisma"                   Offset="707" />
+<Column     Name="Name"          Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Header="Health"                     Offset="150" />
+<Column     Name="Happiness"     Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"     Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"        Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"      Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"   Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"      Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"         Header="Rebel"                      Offset="559" />
+<Column     Name="Age"           Header="Age"                        Offset="596" />
+<Column     Name="is_addict"     Header="Addict"                     Offset="633" />
+<Column     Name="SKILL_Service" Header="Service"                    Offset="670" />
+<Column     Name="STAT_Charisma" Header="Charisma"                   Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/clinic_management_screen.xml
+++ b/Resources/Interface/J_1024x768/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="559" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="596" />
-<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="633" />
-<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="670" />
-<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="707" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="150" />
+<Column     Name="Happiness"         Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Header="Age"                        Offset="596" />
+<Column     Name="has_disease"       Header="Disease"                    Offset="633" />
+<Column     Name="STAT_Intelligence" Header="Int."                       Offset="670" />
+<Column     Name="SKILL_Medicine"    Header="Medicine"                   Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/dungeon_screen.xml
+++ b/Resources/Interface/J_1024x768/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="847"     YPos="690"      Width="150"     Height="40"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="632"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
-<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="150"  />
-<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="187"  />
-<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="224"  />
-<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="261"  />
-<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="317"  />
-<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="373"  />
-<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="429"  />
-<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="485"  />
-<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="541"  />
-<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="597"  />
+<Column     Name="Name"           Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Header="Health"                     Offset="150"  />
+<Column     Name="Happiness"      Header="Happy"                      Offset="187"  />
+<Column     Name="Rebelliousness" Header="Rebel"                      Offset="224"  />
+<Column     Name="is_slave"       Header="Slave"                      Offset="261"  />
+<Column     Name="is_addict"      Header="Addict"                     Offset="317"  />
+<Column     Name="has_disease"    Header="Disease"                    Offset="373"  />
+<Column     Name="Duration"       Header="Weeks In"                   Offset="429"  />
+<Column     Name="Feeding"        Header="Feeding"                    Offset="485"  />
+<Column     Name="Tortured"       Header="Tortured"                   Offset="541"  />
+<Column     Name="Reason"         Header="Reason for Imprisonment"    Offset="597"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="262"      YPos="670"      Width="262"     Height="24"  FontSize="12"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="562"      YPos="670"      Width="150"     Height="24"  FontSize="12"  />

--- a/Resources/Interface/J_1024x768/farm_management_screen.xml
+++ b/Resources/Interface/J_1024x768/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="559" />
-<Column     Name="Age"                  Type="Age"     Header="Age"                        Offset="596" />
-<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="633" />
-<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="670" />
-<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="707" />
+<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Header="Health"                     Offset="150" />
+<Column     Name="Happiness"            Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"            Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"               Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"             Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"          Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"             Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"                Header="Rebel"                      Offset="559" />
+<Column     Name="Age"                  Header="Age"                        Offset="596" />
+<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="633" />
+<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="670" />
+<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/gangs_screen.xml
+++ b/Resources/Interface/J_1024x768/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="7"       YPos="35"       Width="825"     Height="402" FontSize="9" RowHeight="19" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="187"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="299"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="355"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="411"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="467"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="523"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="579"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="635"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="691"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="747"  />
+<Column     Name="GangName"     Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Header="Mission"                    Offset="187"  />
+<Column     Name="Number"       Header="Men"                        Offset="299"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="355"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="411"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="467"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="523"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="579"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="635"  />
+<Column     Name="Service"      Header="Service"                    Offset="691"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="747"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="37"       YPos="425"      Width="45"      Height="44"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="87"      YPos="520"      Width="60"      Height="32"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="157"      YPos="450"      Width="675"     Height="182" FontSize="9" RowHeight="19" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"      Type="String"        Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"        Type="Numeric"       Header="Men"                        Offset="150"  />
-<Column     Name="Combat"        Type="Numeric"       Header="Combat"                     Offset="206"  />
-<Column     Name="Magic"         Type="Numeric"       Header="Magic"                      Offset="262"  />
-<Column     Name="Intelligence"  Type="Numeric"       Header="Intel."                     Offset="318"  />
-<Column     Name="Agility"       Type="Numeric"       Header="Agility"                    Offset="374"  />
-<Column     Name="Constitution"  Type="Numeric"       Header="Tough"                      Offset="430"  />
-<Column     Name="Strength"      Type="Numeric"       Header="Strength"                   Offset="486"  />
-<Column     Name="Service"       Type="Numeric"       Header="Service"                    Offset="542"  />
-<Column     Name="Charisma"      Type="Numeric"       Header="Charisma"                   Offset="598"  />
+<Column     Name="GangName"      Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"        Header="Men"                        Offset="150"  />
+<Column     Name="Combat"        Header="Combat"                     Offset="206"  />
+<Column     Name="Magic"         Header="Magic"                      Offset="262"  />
+<Column     Name="Intelligence"  Header="Intel."                     Offset="318"  />
+<Column     Name="Agility"       Header="Agility"                    Offset="374"  />
+<Column     Name="Constitution"  Header="Tough"                      Offset="430"  />
+<Column     Name="Strength"      Header="Strength"                   Offset="486"  />
+<Column     Name="Service"       Header="Service"                    Offset="542"  />
+<Column     Name="Charisma"      Header="Charisma"                   Offset="598"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="847"     YPos="8"        Width="150"     Height="32"  FontSize="13"  />

--- a/Resources/Interface/J_1024x768/girl_management_screen.xml
+++ b/Resources/Interface/J_1024x768/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="559" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="596" />
-<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="633" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="670" />
-<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="707" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="150" />
+<Column     Name="Happiness"         Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Header="Age"                        Offset="596" />
+<Column     Name="Looks"             Header="Looks"                      Offset="633" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="670" />
+<Column     Name="SexAverage"        Header="Avg.Sex"                    Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/house_management_screen.xml
+++ b/Resources/Interface/J_1024x768/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="559" />
-<Column     Name="Age"          Type="Age"        Header="Age"                        Offset="596" />
-<Column     Name="SO"           Type="String"         Header="SO"                         Offset="633" />
-<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="670" />
-<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="707" />
+<Column     Name="Name"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Header="Health"                     Offset="150" />
+<Column     Name="Happiness"    Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"    Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"       Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"     Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"  Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"     Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"        Header="Rebel"                      Offset="559" />
+<Column     Name="Age"          Header="Age"                        Offset="596" />
+<Column     Name="SO"           Header="SO"                         Offset="633" />
+<Column     Name="STAT_PCLove"  Header="Love"                       Offset="670" />
+<Column     Name="SkillAverage" Header="Skill Avg."                 Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1024x768/studio_management_screen.xml
+++ b/Resources/Interface/J_1024x768/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="322"      YPos="650"      Width="277"     Height="90"     FontSize="7"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="862"     YPos="650"      Width="120"     Height="32"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="7"       YPos="35"       Width="765"     Height="548"    FontSize="9"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="150" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="187" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="224" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="261" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="373" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="485" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="522" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="559" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="596" />
-<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="633" />
-<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="670" />
-<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="707" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="150" />
+<Column     Name="Happiness"         Header="Happy"                      Offset="187" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="224" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="261" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="373" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="485" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="522" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="559" />
+<Column     Name="Age"               Header="Age"                        Offset="596" />
+<Column     Name="Looks"             Header="Looks"                      Offset="633" />
+<Column     Name="STAT_Fame"         Header="Fame"                       Offset="670" />
+<Column     Name="SKILL_Performance" Header="Perform"                    Offset="707" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/arena_management_screen.xml
+++ b/Resources/Interface/J_1366x768/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="750" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="800" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="850" />
-<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="900" />
-<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="950" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="200" />
+<Column     Name="Happiness"         Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Header="Age"                        Offset="800" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="850" />
+<Column     Name="SKILL_Magic"       Header="Magic"                      Offset="900" />
+<Column     Name="SKILL_Combat"      Header="Combat"                     Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/centre_management_screen.xml
+++ b/Resources/Interface/J_1366x768/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="750" />
-<Column     Name="Age"           Type="Age"            Header="Age"                        Offset="800" />
-<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="850" />
-<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="900" />
-<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="950" />
+<Column     Name="Name"          Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"     Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"     Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"        Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"      Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"   Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"      Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"         Header="Rebel"                      Offset="750" />
+<Column     Name="Age"           Header="Age"                        Offset="800" />
+<Column     Name="is_addict"     Header="Addict"                     Offset="850" />
+<Column     Name="SKILL_Service" Header="Service"                    Offset="900" />
+<Column     Name="STAT_Charisma" Header="Charisma"                   Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/clinic_management_screen.xml
+++ b/Resources/Interface/J_1366x768/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="750" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="800" />
-<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="850" />
-<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="900" />
-<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="950" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Header="Age"                        Offset="800" />
+<Column     Name="has_disease"       Header="Disease"                    Offset="850" />
+<Column     Name="STAT_Intelligence" Header="Int."                       Offset="900" />
+<Column     Name="SKILL_Medicine"    Header="Medicine"                   Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/dungeon_screen.xml
+++ b/Resources/Interface/J_1366x768/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="1130"     YPos="690"      Width="200"     Height="40"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="632"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
-<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="200"  />
-<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="250"  />
-<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="300"  />
-<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="350"  />
-<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="425"  />
-<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="500"  />
-<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="575"  />
-<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="650"  />
-<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="725"  />
-<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="800"  />
+<Column     Name="Name"           Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Header="Health"                     Offset="200"  />
+<Column     Name="Happiness"      Header="Happy"                      Offset="250"  />
+<Column     Name="Rebelliousness" Header="Rebel"                      Offset="300"  />
+<Column     Name="is_slave"       Header="Slave"                      Offset="350"  />
+<Column     Name="is_addict"      Header="Addict"                     Offset="425"  />
+<Column     Name="has_disease"    Header="Disease"                    Offset="500"  />
+<Column     Name="Duration"       Header="Weeks In"                   Offset="575"  />
+<Column     Name="Feeding"        Header="Feeding"                    Offset="650"  />
+<Column     Name="Tortured"       Header="Tortured"                   Offset="725"  />
+<Column     Name="Reason"         Header="Reason for Imprisonment"    Offset="800"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="350"      YPos="670"      Width="350"     Height="24"  FontSize="16"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="750"      YPos="670"      Width="200"     Height="24"  FontSize="16"  />

--- a/Resources/Interface/J_1366x768/farm_management_screen.xml
+++ b/Resources/Interface/J_1366x768/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="750" />
-<Column     Name="Age"                  Type="Age"     Header="Age"                        Offset="800" />
-<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="850" />
-<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="900" />
-<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="950" />
+<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"            Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"            Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"               Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"             Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"          Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"             Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"                Header="Rebel"                      Offset="750" />
+<Column     Name="Age"                  Header="Age"                        Offset="800" />
+<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="850" />
+<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="900" />
+<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/gangs_screen.xml
+++ b/Resources/Interface/J_1366x768/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="10"       YPos="35"       Width="1100"     Height="402" FontSize="12" RowHeight="19" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="250"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="400"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="475"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="550"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="625"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="700"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="775"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="850"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="925"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1000"  />
+<Column     Name="GangName"     Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Header="Mission"                    Offset="250"  />
+<Column     Name="Number"       Header="Men"                        Offset="400"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="475"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="550"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="625"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="700"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="775"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="850"  />
+<Column     Name="Service"      Header="Service"                    Offset="925"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="1000"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="50"       YPos="425"      Width="60"      Height="44"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="116"      YPos="520"      Width="80"      Height="32"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="210"      YPos="450"      Width="900"     Height="182" FontSize="12" RowHeight="19" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="200"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="275"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="350"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="425"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="500"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="575"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="650"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="725"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="800"  />
+<Column     Name="GangName"     Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Header="Men"                        Offset="200"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="275"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="350"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="425"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="500"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="575"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="650"  />
+<Column     Name="Service"      Header="Service"                    Offset="725"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="800"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="1130"     YPos="8"        Width="200"     Height="32"  FontSize="18"  />

--- a/Resources/Interface/J_1366x768/girl_management_screen.xml
+++ b/Resources/Interface/J_1366x768/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="750" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="800" />
-<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="850" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="900" />
-<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="950" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Header="Age"                        Offset="800" />
+<Column     Name="Looks"             Header="Looks"                      Offset="850" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="900" />
+<Column     Name="SexAverage"        Header="Avg.Sex"                    Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/house_management_screen.xml
+++ b/Resources/Interface/J_1366x768/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="750" />
-<Column     Name="Age"          Type="Age"        Header="Age"                        Offset="800" />
-<Column     Name="SO"           Type="String"         Header="SO"                         Offset="850" />
-<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="900" />
-<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="950" />
+<Column     Name="Name"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"    Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"    Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"       Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"     Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"  Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"     Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"        Header="Rebel"                      Offset="750" />
+<Column     Name="Age"          Header="Age"                        Offset="800" />
+<Column     Name="SO"           Header="SO"                         Offset="850" />
+<Column     Name="STAT_PCLove"  Header="Love"                       Offset="900" />
+<Column     Name="SkillAverage" Header="Skill Avg."                 Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1366x768/studio_management_screen.xml
+++ b/Resources/Interface/J_1366x768/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="430"      YPos="650"      Width="370"     Height="90"     FontSize="10"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1150"     YPos="650"      Width="160"     Height="32"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="10"       YPos="35"       Width="1020"     Height="548"    FontSize="12"       RowHeight="21"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="200" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="250" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="300" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="350" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="500" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="650" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="700" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="750" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="800" />
-<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="850" />
-<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="900" />
-<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="950" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="200" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="250" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="300" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="350" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="500" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="650" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="700" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="750" />
+<Column     Name="Age"               Header="Age"                        Offset="800" />
+<Column     Name="Looks"             Header="Looks"                      Offset="850" />
+<Column     Name="STAT_Fame"         Header="Fame"                       Offset="900" />
+<Column     Name="SKILL_Performance" Header="Perform"                    Offset="950" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/arena_management_screen.xml
+++ b/Resources/Interface/J_1600x900/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="881" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="940" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="999" />
-<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="1058" />
-<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="1117" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Header="Age"                        Offset="940" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="999" />
+<Column     Name="SKILL_Magic"       Header="Magic"                      Offset="1058" />
+<Column     Name="SKILL_Combat"      Header="Combat"                     Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/centre_management_screen.xml
+++ b/Resources/Interface/J_1600x900/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="881" />
-<Column     Name="Age"           Type="Age"            Header="Age"                        Offset="940" />
-<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="999" />
-<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="1058" />
-<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="1117" />
+<Column     Name="Name"          Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"     Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"     Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"        Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"      Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"   Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"      Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"         Header="Rebel"                      Offset="881" />
+<Column     Name="Age"           Header="Age"                        Offset="940" />
+<Column     Name="is_addict"     Header="Addict"                     Offset="999" />
+<Column     Name="SKILL_Service" Header="Service"                    Offset="1058" />
+<Column     Name="STAT_Charisma" Header="Charisma"                   Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/clinic_management_screen.xml
+++ b/Resources/Interface/J_1600x900/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="881" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="940" />
-<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="999" />
-<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="1058" />
-<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="1117" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Header="Age"                        Offset="940" />
+<Column     Name="has_disease"       Header="Disease"                    Offset="999" />
+<Column     Name="STAT_Intelligence" Header="Int."                       Offset="1058" />
+<Column     Name="SKILL_Medicine"    Header="Medicine"                   Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/dungeon_screen.xml
+++ b/Resources/Interface/J_1600x900/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="1324"     YPos="809"      Width="234"     Height="47"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="741"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
-<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="234"  />
-<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="293"  />
-<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="352"  />
-<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="411"  />
-<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="499"  />
-<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="587"  />
-<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="675"  />
-<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="763"  />
-<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="851"  />
-<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="939"  />
+<Column     Name="Name"           Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Header="Health"                     Offset="234"  />
+<Column     Name="Happiness"      Header="Happy"                      Offset="293"  />
+<Column     Name="Rebelliousness" Header="Rebel"                      Offset="352"  />
+<Column     Name="is_slave"       Header="Slave"                      Offset="411"  />
+<Column     Name="is_addict"      Header="Addict"                     Offset="499"  />
+<Column     Name="has_disease"    Header="Disease"                    Offset="587"  />
+<Column     Name="Duration"       Header="Weeks In"                   Offset="675"  />
+<Column     Name="Feeding"        Header="Feeding"                    Offset="763"  />
+<Column     Name="Tortured"       Header="Tortured"                   Offset="851"  />
+<Column     Name="Reason"         Header="Reason for Imprisonment"    Offset="939"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="410"      YPos="785"      Width="410"     Height="28"  FontSize="19"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="878"      YPos="785"      Width="234"     Height="28"  FontSize="19"  />

--- a/Resources/Interface/J_1600x900/farm_management_screen.xml
+++ b/Resources/Interface/J_1600x900/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="881" />
-<Column     Name="Age"                  Type="Age"     Header="Age"                        Offset="940" />
-<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="999" />
-<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="1058" />
-<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="1117" />
+<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"            Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"            Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"               Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"             Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"          Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"             Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"                Header="Rebel"                      Offset="881" />
+<Column     Name="Age"                  Header="Age"                        Offset="940" />
+<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="999" />
+<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="1058" />
+<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/gangs_screen.xml
+++ b/Resources/Interface/J_1600x900/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="12"       YPos="41"       Width="1288"     Height="471" FontSize="14" RowHeight="22" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="293"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="469"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="557"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="645"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="733"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="821"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="909"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="997"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="1085"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1173"  />
+<Column     Name="GangName"     Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Header="Mission"                    Offset="293"  />
+<Column     Name="Number"       Header="Men"                        Offset="469"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="557"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="645"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="733"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="821"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="909"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="997"  />
+<Column     Name="Service"      Header="Service"                    Offset="1085"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="1173"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="59"       YPos="498"      Width="70"      Height="52"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="136"      YPos="609"      Width="94"      Height="38"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="246"      YPos="527"      Width="1054"     Height="213" FontSize="14" RowHeight="22" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="234"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="322"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="410"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="498"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="586"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="674"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="762"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="850"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="938"  />
+<Column     Name="GangName"     Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Header="Men"                        Offset="234"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="322"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="410"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="498"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="586"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="674"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="762"  />
+<Column     Name="Service"      Header="Service"                    Offset="850"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="938"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="1324"     YPos="9"        Width="234"     Height="38"  FontSize="21"  />

--- a/Resources/Interface/J_1600x900/girl_management_screen.xml
+++ b/Resources/Interface/J_1600x900/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="881" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="940" />
-<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="999" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="1058" />
-<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="1117" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Header="Age"                        Offset="940" />
+<Column     Name="Looks"             Header="Looks"                      Offset="999" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="1058" />
+<Column     Name="SexAverage"        Header="Avg.Sex"                    Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/house_management_screen.xml
+++ b/Resources/Interface/J_1600x900/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="881" />
-<Column     Name="Age"          Type="Age"        Header="Age"                        Offset="940" />
-<Column     Name="SO"           Type="String"         Header="SO"                         Offset="999" />
-<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="1058" />
-<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="1117" />
+<Column     Name="Name"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"    Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"    Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"       Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"     Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"  Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"     Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"        Header="Rebel"                      Offset="881" />
+<Column     Name="Age"          Header="Age"                        Offset="940" />
+<Column     Name="SO"           Header="SO"                         Offset="999" />
+<Column     Name="STAT_PCLove"  Header="Love"                       Offset="1058" />
+<Column     Name="SkillAverage" Header="Skill Avg."                 Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1600x900/studio_management_screen.xml
+++ b/Resources/Interface/J_1600x900/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="504"      YPos="762"      Width="433"     Height="105"     FontSize="12"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1347"     YPos="762"      Width="187"     Height="38"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="12"       YPos="41"       Width="1195"     Height="642"    FontSize="14"       RowHeight="25"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="234" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="293" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="352" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="411" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="587" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="763" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="822" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="881" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="940" />
-<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="999" />
-<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="1058" />
-<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="1117" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="234" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="293" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="352" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="411" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="587" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="763" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="822" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="881" />
+<Column     Name="Age"               Header="Age"                        Offset="940" />
+<Column     Name="Looks"             Header="Looks"                      Offset="999" />
+<Column     Name="STAT_Fame"         Header="Fame"                       Offset="1058" />
+<Column     Name="SKILL_Performance" Header="Perform"                    Offset="1117" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/arena_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="1123" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="1193" />
-<Column     Name="SKILL_Magic"       Type="Numeric"    Header="Magic"                      Offset="1263" />
-<Column     Name="SKILL_Combat"      Type="Numeric"    Header="Combat"                     Offset="1333" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Header="Age"                        Offset="1123" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="1193" />
+<Column     Name="SKILL_Magic"       Header="Magic"                      Offset="1263" />
+<Column     Name="SKILL_Combat"      Header="Combat"                     Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/centre_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"           Type="Age"            Header="Age"                        Offset="1123" />
-<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="1193" />
-<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="1263" />
-<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="1333" />
+<Column     Name="Name"          Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"     Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"     Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"        Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"      Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"   Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"      Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"         Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"           Header="Age"                        Offset="1123" />
+<Column     Name="is_addict"     Header="Addict"                     Offset="1193" />
+<Column     Name="SKILL_Service" Header="Service"                    Offset="1263" />
+<Column     Name="STAT_Charisma" Header="Charisma"                   Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/clinic_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="1123" />
-<Column     Name="has_disease"       Type="String"     Header="Disease"                    Offset="1193" />
-<Column     Name="STAT_Intelligence" Type="Numeric"    Header="Int."                       Offset="1263" />
-<Column     Name="SKILL_Medicine"    Type="Numeric"    Header="Medicine"                   Offset="1333" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Header="Age"                        Offset="1123" />
+<Column     Name="has_disease"       Header="Disease"                    Offset="1193" />
+<Column     Name="STAT_Intelligence" Header="Int."                       Offset="1263" />
+<Column     Name="SKILL_Medicine"    Header="Medicine"                   Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/dungeon_screen.xml
+++ b/Resources/Interface/J_1920x1080/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="1588"     YPos="970"      Width="281"     Height="56"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="889"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
-<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="281"  />
-<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="351"  />
-<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="421"  />
-<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="491"  />
-<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="596"  />
-<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="701"  />
-<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="806"  />
-<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="911"  />
-<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="1016"  />
-<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="1121"  />
+<Column     Name="Name"           Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Header="Health"                     Offset="281"  />
+<Column     Name="Happiness"      Header="Happy"                      Offset="351"  />
+<Column     Name="Rebelliousness" Header="Rebel"                      Offset="421"  />
+<Column     Name="is_slave"       Header="Slave"                      Offset="491"  />
+<Column     Name="is_addict"      Header="Addict"                     Offset="596"  />
+<Column     Name="has_disease"    Header="Disease"                    Offset="701"  />
+<Column     Name="Duration"       Header="Weeks In"                   Offset="806"  />
+<Column     Name="Feeding"        Header="Feeding"                    Offset="911"  />
+<Column     Name="Tortured"       Header="Tortured"                   Offset="1016"  />
+<Column     Name="Reason"         Header="Reason for Imprisonment"    Offset="1121"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="492"      YPos="942"      Width="492"     Height="34"  FontSize="22"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="1054"      YPos="942"      Width="281"     Height="34"  FontSize="22"  />

--- a/Resources/Interface/J_1920x1080/farm_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"                  Type="Age"     Header="Age"                        Offset="1123" />
-<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="1193" />
-<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="1263" />
-<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="1333" />
+<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"            Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"            Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"               Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"             Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"          Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"             Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"                Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"                  Header="Age"                        Offset="1123" />
+<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="1193" />
+<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="1263" />
+<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/gangs_screen.xml
+++ b/Resources/Interface/J_1920x1080/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="14"       YPos="49"       Width="1546"     Height="565" FontSize="17" RowHeight="27" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="351"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="562"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="667"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="772"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="877"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="982"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="1087"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="1192"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="1297"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1402"  />
+<Column     Name="GangName"     Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Header="Mission"                    Offset="351"  />
+<Column     Name="Number"       Header="Men"                        Offset="562"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="667"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="772"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="877"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="982"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="1087"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="1192"  />
+<Column     Name="Service"      Header="Service"                    Offset="1297"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="1402"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="70"       YPos="598"      Width="84"      Height="62"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="163"      YPos="731"      Width="112"      Height="45"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="295"      YPos="633"      Width="1265"     Height="256" FontSize="17" RowHeight="27" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="281"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="386"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="491"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="596"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="701"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="806"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="911"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="1016"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="1121"  />
+<Column     Name="GangName"     Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Header="Men"                        Offset="281"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="386"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="491"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="596"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="701"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="806"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="911"  />
+<Column     Name="Service"      Header="Service"                    Offset="1016"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="1121"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="1588"     YPos="11"        Width="281"     Height="45"  FontSize="25"  />

--- a/Resources/Interface/J_1920x1080/girl_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="1123" />
-<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="1193" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="1263" />
-<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="1333" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Header="Age"                        Offset="1123" />
+<Column     Name="Looks"             Header="Looks"                      Offset="1193" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="1263" />
+<Column     Name="SexAverage"        Header="Avg.Sex"                    Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/house_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"          Type="Age"        Header="Age"                        Offset="1123" />
-<Column     Name="SO"           Type="String"         Header="SO"                         Offset="1193" />
-<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="1263" />
-<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="1333" />
+<Column     Name="Name"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"    Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"    Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"       Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"     Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"  Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"     Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"        Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"          Header="Age"                        Offset="1123" />
+<Column     Name="SO"           Header="SO"                         Offset="1193" />
+<Column     Name="STAT_PCLove"  Header="Love"                       Offset="1263" />
+<Column     Name="SkillAverage" Header="Skill Avg."                 Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_1920x1080/studio_management_screen.xml
+++ b/Resources/Interface/J_1920x1080/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="604"      YPos="914"      Width="520"     Height="127"     FontSize="14"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="1616"     YPos="914"      Width="225"     Height="45"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="14"       YPos="49"       Width="1434"     Height="771"    FontSize="17"       RowHeight="30"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="281" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="351" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="421" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="491" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="702" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="913" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="983" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="1053" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="1123" />
-<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="1193" />
-<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="1263" />
-<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="1333" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="281" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="351" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="421" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="491" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="702" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="913" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="983" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="1053" />
+<Column     Name="Age"               Header="Age"                        Offset="1123" />
+<Column     Name="Looks"             Header="Looks"                      Offset="1193" />
+<Column     Name="STAT_Fame"         Header="Fame"                       Offset="1263" />
+<Column     Name="SKILL_Performance" Header="Perform"                    Offset="1333" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/arena_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/arena_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="2252" />
-<Column     Name="STAT_Constitution" Type="Numeric"   Header="Const."                     Offset="2393" />
-<Column     Name="SKILL_Magic"       Type="Numeric"   Header="Magic"                      Offset="2534" />
-<Column     Name="SKILL_Combat"      Type="Numeric"   Header="Combat"                     Offset="2675" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Header="Age"                        Offset="2252" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="2393" />
+<Column     Name="SKILL_Magic"       Header="Magic"                      Offset="2534" />
+<Column     Name="SKILL_Combat"      Header="Combat"                     Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/centre_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/centre_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"          Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"        Type="Numeric"        Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"     Type="Numeric"        Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"     Type="Numeric"        Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"        Type="String"         Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"      Type="String"         Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"   Type="String"         Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"      Type="String"         Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"         Type="Numeric"        Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"           Type="Age"            Header="Age"                        Offset="2252" />
-<Column     Name="is_addict"     Type="String"         Header="Addict"                     Offset="2393" />
-<Column     Name="SKILL_Service" Type="Numeric"        Header="Service"                    Offset="2534" />
-<Column     Name="STAT_Charisma" Type="Numeric"        Header="Charisma"                   Offset="2675" />
+<Column     Name="Name"          Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"        Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"     Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"     Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"        Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"      Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"   Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"      Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"         Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"           Header="Age"                        Offset="2252" />
+<Column     Name="is_addict"     Header="Addict"                     Offset="2393" />
+<Column     Name="SKILL_Service" Header="Service"                    Offset="2534" />
+<Column     Name="STAT_Charisma" Header="Charisma"                   Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/clinic_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/clinic_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="2252" />
-<Column     Name="has_disease"       Type="String"    Header="Disease"                    Offset="2393" />
-<Column     Name="STAT_Intelligence" Type="Numeric"   Header="Int."                       Offset="2534" />
-<Column     Name="SKILL_Medicine"    Type="Numeric"   Header="Medicine"                   Offset="2675" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Header="Age"                        Offset="2252" />
+<Column     Name="has_disease"       Header="Disease"                    Offset="2393" />
+<Column     Name="STAT_Intelligence" Header="Int."                       Offset="2534" />
+<Column     Name="SKILL_Medicine"    Header="Medicine"                   Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/dungeon_screen.xml
+++ b/Resources/Interface/J_3840x2160/dungeon_screen.xml
@@ -19,17 +19,17 @@
 <Button     Name="BackButton"           Image="Back"                        XPos="3177"     YPos="1941"      Width="562"     Height="112"     Transparency="true" PushWindow="<back>"/>
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1778"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"           Type="String"       Header="Girl Name"                  Offset="0"  />
-<Column     Name="Health"         Type="Numeric"      Header="Health"                     Offset="562"  />
-<Column     Name="Happiness"      Type="Numeric"      Header="Happy"                      Offset="703"  />
-<Column     Name="Rebelliousness" Type="Numeric"      Header="Rebel"                      Offset="844"  />
-<Column     Name="is_slave"       Type="String"       Header="Slave"                      Offset="985"  />
-<Column     Name="is_addict"      Type="String"       Header="Addict"                     Offset="1196"  />
-<Column     Name="has_disease"    Type="String"       Header="Disease"                    Offset="1407"  />
-<Column     Name="Duration"       Type="Numeric"      Header="Weeks In"                   Offset="1618"  />
-<Column     Name="Feeding"        Type="String"       Header="Feeding"                    Offset="1829"  />
-<Column     Name="Tortured"       Type="String"       Header="Tortured"                   Offset="2040"  />
-<Column     Name="Reason"         Type="String"       Header="Reason for Imprisonment"    Offset="2251"  />
+<Column     Name="Name"           Header="Girl Name"                  Offset="0"  />
+<Column     Name="Health"         Header="Health"                     Offset="562"  />
+<Column     Name="Happiness"      Header="Happy"                      Offset="703"  />
+<Column     Name="Rebelliousness" Header="Rebel"                      Offset="844"  />
+<Column     Name="is_slave"       Header="Slave"                      Offset="985"  />
+<Column     Name="is_addict"      Header="Addict"                     Offset="1196"  />
+<Column     Name="has_disease"    Header="Disease"                    Offset="1407"  />
+<Column     Name="Duration"       Header="Weeks In"                   Offset="1618"  />
+<Column     Name="Feeding"        Header="Feeding"                    Offset="1829"  />
+<Column     Name="Tortured"       Header="Tortured"                   Offset="2040"  />
+<Column     Name="Reason"         Header="Reason for Imprisonment"    Offset="2251"  />
 </ListBox>                                                                                                                  
 <Text       Name="ReleaseTo"            Text="Send Girl to: Brothel 0"      XPos="984"      YPos="1884"      Width="984"     Height="68"  FontSize="45"  />
 <Text       Name="RoomsFree"            Text="Room for # more girls."       XPos="2108"      YPos="1884"      Width="562"     Height="68"  FontSize="45"  />

--- a/Resources/Interface/J_3840x2160/farm_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/farm_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"                 Type="String"  Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"               Type="Numeric" Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"            Type="Numeric" Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"            Type="Numeric" Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"               Type="String"  Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"             Type="String"  Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"          Type="String"  Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"             Type="String"  Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"                Type="Numeric" Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"                  Type="Age"     Header="Age"                        Offset="2252" />
-<Column     Name="SKILL_Farming"        Type="Numeric" Header="Farm"                       Offset="2393" />
-<Column     Name="SKILL_Crafting"       Type="Numeric" Header="Craft"                      Offset="2534" />
-<Column     Name="SKILL_AnimalHandling" Type="Numeric" Header="Anm.Hnd."                   Offset="2675" />
+<Column     Name="Name"                 Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"               Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"            Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"            Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"               Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"             Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"          Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"             Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"                Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"                  Header="Age"                        Offset="2252" />
+<Column     Name="SKILL_Farming"        Header="Farm"                       Offset="2393" />
+<Column     Name="SKILL_Crafting"       Header="Craft"                      Offset="2534" />
+<Column     Name="SKILL_AnimalHandling" Header="Anm.Hnd."                   Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/gangs_screen.xml
+++ b/Resources/Interface/J_3840x2160/gangs_screen.xml
@@ -6,17 +6,17 @@
 
 
 <ListBox    Name="GangList"                                                 XPos="28"       YPos="98"       Width="3092"     Height="1131" FontSize="34" RowHeight="53" Border="1" Events="true" Multi="true" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Gang Name"                  Offset="0"  />
-<Column     Name="Mission"      Type="String"         Header="Mission"                    Offset="703"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="1125"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="1336"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="1547"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="1758"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="1969"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="2180"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="2391"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="2602"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="2813"  />
+<Column     Name="GangName"     Header="Gang Name"                  Offset="0"  />
+<Column     Name="Mission"      Header="Mission"                    Offset="703"  />
+<Column     Name="Number"       Header="Men"                        Offset="1125"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="1336"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="1547"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="1758"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="1969"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="2180"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="2391"  />
+<Column     Name="Service"      Header="Service"                    Offset="2602"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="2813"  />
 </ListBox>
 
 <Image      Name="FireArrow"            File="imgArrowDown.png"             XPos="141"       YPos="1195"      Width="169"      Height="124"  />
@@ -25,16 +25,16 @@
 <Button     Name="GangHireButton"       Image="Hire"                        XPos="326"      YPos="1462"      Width="225"      Height="90"  Transparency="true"/>
 
 <ListBox    Name="RecruitList"                                              XPos="590"      YPos="1266"      Width="2530"     Height="512" FontSize="34" RowHeight="53" Border="1" Events="true" Multi="false" ShowHeaders="true" HeaderDiv="true" HeaderClicksSort="true" >
-<Column     Name="GangName"     Type="String"         Header="Recruitable Gang"           Offset="0"  />
-<Column     Name="Number"       Type="Numeric"        Header="Men"                        Offset="562"  />
-<Column     Name="Combat"       Type="Numeric"        Header="Combat"                     Offset="773"  />
-<Column     Name="Magic"        Type="Numeric"        Header="Magic"                      Offset="984"  />
-<Column     Name="Intelligence" Type="Numeric"        Header="Intel."                     Offset="1195"  />
-<Column     Name="Agility"      Type="Numeric"        Header="Agility"                    Offset="1406"  />
-<Column     Name="Constitution" Type="Numeric"        Header="Tough"                      Offset="1617"  />
-<Column     Name="Strength"     Type="Numeric"        Header="Strength"                   Offset="1828"  />
-<Column     Name="Service"      Type="Numeric"        Header="Service"                    Offset="2039"  />
-<Column     Name="Charisma"     Type="Numeric"        Header="Charisma"                   Offset="2250"  />
+<Column     Name="GangName"     Header="Recruitable Gang"           Offset="0"  />
+<Column     Name="Number"       Header="Men"                        Offset="562"  />
+<Column     Name="Combat"       Header="Combat"                     Offset="773"  />
+<Column     Name="Magic"        Header="Magic"                      Offset="984"  />
+<Column     Name="Intelligence" Header="Intel."                     Offset="1195"  />
+<Column     Name="Agility"      Header="Agility"                    Offset="1406"  />
+<Column     Name="Constitution" Header="Tough"                      Offset="1617"  />
+<Column     Name="Strength"     Header="Strength"                   Offset="1828"  />
+<Column     Name="Service"      Header="Service"                    Offset="2039"  />
+<Column     Name="Charisma"     Header="Charisma"                   Offset="2250"  />
 </ListBox>
 
 <Text       Name="txtMissions"          Text="Available Missions"           XPos="3177"     YPos="22"        Width="562"     Height="90"  FontSize="51"  />

--- a/Resources/Interface/J_3840x2160/girl_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/girl_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"     Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"    Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"         Type="Numeric"    Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"         Type="Numeric"    Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"            Type="String"     Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"          Type="String"     Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"       Type="String"     Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"          Type="String"     Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"             Type="Numeric"    Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"               Type="Age"        Header="Age"                        Offset="2252" />
-<Column     Name="Looks"             Type="Numeric"    Header="Looks"                      Offset="2393" />
-<Column     Name="STAT_Constitution" Type="Numeric"    Header="Const."                     Offset="2534" />
-<Column     Name="SexAverage"        Type="Numeric"    Header="Avg.Sex"                    Offset="2675" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Header="Age"                        Offset="2252" />
+<Column     Name="Looks"             Header="Looks"                      Offset="2393" />
+<Column     Name="STAT_Constitution" Header="Const."                     Offset="2534" />
+<Column     Name="SexAverage"        Header="Avg.Sex"                    Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/house_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/house_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />    
 
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"         Type="String"         Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"       Type="Numeric"        Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"    Type="Numeric"        Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"    Type="Numeric"        Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"       Type="String"         Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"     Type="String"         Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"  Type="String"         Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"     Type="String"         Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"        Type="Numeric"        Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"          Type="Age"        Header="Age"                        Offset="2252" />
-<Column     Name="SO"           Type="String"         Header="SO"                         Offset="2393" />
-<Column     Name="STAT_PCLove"  Type="Numeric"        Header="Love"                       Offset="2534" />
-<Column     Name="SkillAverage" Type="Numeric"        Header="Skill Avg."                 Offset="2675" />
+<Column     Name="Name"         Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"       Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"    Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"    Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"       Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"     Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"  Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"     Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"        Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"          Header="Age"                        Offset="2252" />
+<Column     Name="SO"           Header="SO"                         Offset="2393" />
+<Column     Name="STAT_PCLove"  Header="Love"                       Offset="2534" />
+<Column     Name="SkillAverage" Header="Skill Avg."                 Offset="2675" />
 </ListBox>
 </Screen>

--- a/Resources/Interface/J_3840x2160/studio_management_screen.xml
+++ b/Resources/Interface/J_3840x2160/studio_management_screen.xml
@@ -21,18 +21,18 @@
 <Text       Name="JobDescription"       Text=""                             XPos="1209"      YPos="1828"      Width="1040"     Height="253"     FontSize="28"  />
 <Button     Name="CreateMovieButton"    Image="CreateMovie"                 XPos="3233"     YPos="1828"      Width="450"     Height="90"     Transparency="true" PushWindow="Movie Maker"/>
 <ListBox    Name="GirlList"                                                 XPos="28"       YPos="98"       Width="2867"     Height="1541"    FontSize="34"       RowHeight="59"      Border="1"          Events="true"      Multi="true"   ShowHeaders="true"   HeaderDiv="true"   HeaderClicksSort="true"   >
-<Column     Name="Name"              Type="String"    Header="Girl Name"                  Offset="0" />
-<Column     Name="Health"            Type="Numeric"   Header="Health"                     Offset="562" /> 
-<Column     Name="Happiness"         Type="Numeric"   Header="Happy"                      Offset="703" />
-<Column     Name="Tiredness"         Type="Numeric"   Header="Tired"                      Offset="844" />
-<Column     Name="DayJob"            Type="String"    Header="Day Job"                    Offset="985" />
-<Column     Name="NightJob"          Type="String"    Header="Night Job"                  Offset="1407" />
-<Column     Name="is_pregnant"       Type="String"    Header="Preg"                       Offset="1829" />
-<Column     Name="is_slave"          Type="String"    Header="Slave"                      Offset="1970" />
-<Column     Name="Rebel"             Type="Numeric"   Header="Rebel"                      Offset="2111" />
-<Column     Name="Age"               Type="Age"       Header="Age"                        Offset="2252" />
-<Column     Name="Looks"             Type="Numeric"   Header="Looks"                      Offset="2393" />
-<Column     Name="STAT_Fame"         Type="Numeric"   Header="Fame"                       Offset="2534" />
-<Column     Name="SKILL_Performance" Type="Numeric"   Header="Perform"                    Offset="2675" />
+<Column     Name="Name"              Header="Girl Name"                  Offset="0" />
+<Column     Name="Health"            Header="Health"                     Offset="562" /> 
+<Column     Name="Happiness"         Header="Happy"                      Offset="703" />
+<Column     Name="Tiredness"         Header="Tired"                      Offset="844" />
+<Column     Name="DayJob"            Header="Day Job"                    Offset="985" />
+<Column     Name="NightJob"          Header="Night Job"                  Offset="1407" />
+<Column     Name="is_pregnant"       Header="Preg"                       Offset="1829" />
+<Column     Name="is_slave"          Header="Slave"                      Offset="1970" />
+<Column     Name="Rebel"             Header="Rebel"                      Offset="2111" />
+<Column     Name="Age"               Header="Age"                        Offset="2252" />
+<Column     Name="Looks"             Header="Looks"                      Offset="2393" />
+<Column     Name="STAT_Fame"         Header="Fame"                       Offset="2534" />
+<Column     Name="SKILL_Performance" Header="Perform"                    Offset="2675" />
 </ListBox>
 </Screen>

--- a/src/engine/include/interface/TableCells.h
+++ b/src/engine/include/interface/TableCells.h
@@ -1,0 +1,75 @@
+#if !defined(SEEN_ENGINE_TABLECELLS_H_20201022_)
+#define SEEN_ENGINE_TABLECELLS_H_20201022_ 1
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <boost/variant.hpp>
+
+/// An error type for our cell data.
+///
+/// Currently this is a singleton type (so all errors are effectively
+/// the same).
+struct Error
+{
+   constexpr friend bool operator==(Error, Error) { return true;}
+   constexpr friend bool operator< (Error, Error) { return false;}
+};
+
+/// Data that we want to put in a \c cListBox cell.
+using CellData = boost::variant<std::string, int, bool, Error>;
+
+/// Cell data with attached formatting.
+struct FormattedCellData {
+   CellData val_;
+   std::string fmt_;
+};
+
+/// Create a formatted cell with text.
+inline
+FormattedCellData mk_text(std::string val)
+{
+   auto str = val;
+   return FormattedCellData{std::move(val), std::move(str)};
+}
+
+/// Create a formatted cell with an error.
+inline
+FormattedCellData mk_error(std::string errtext)
+{
+   return FormattedCellData{Error{}, std::move(errtext)};
+}
+
+/// Create a formatted cell with a numeric value.
+inline
+FormattedCellData mk_num(int val)
+{
+   return FormattedCellData{val, std::to_string(val)};
+};
+
+/// Create a formatted "Yes/No" cell.
+inline
+FormattedCellData mk_yesno(bool val)
+{
+   return FormattedCellData{val, val ? "Yes" : "No"};
+};
+
+/// Create a formatted cell with a numeric percentage.
+inline
+FormattedCellData mk_percent(int val)
+{
+   return FormattedCellData{val, std::to_string(val) + '%'};
+};
+
+/// Create a formatted cell with a health value.
+inline
+FormattedCellData mk_health(int val)
+{
+   if(val <= 0)
+      return FormattedCellData{val, "DEAD"};
+   else
+      return FormattedCellData{val, std::to_string(val) + '%'};
+};
+
+#endif

--- a/src/engine/include/interface/cInterfaceWindow.h
+++ b/src/engine/include/interface/cInterfaceWindow.h
@@ -95,9 +95,9 @@ public:
 
     // List Boxes
     void AddToListBox(int listBoxID, int dataID, std::string data, int color = COLOR_BLUE);
-    void AddToListBox(int listBoxID, int dataID, ItemData value, std::string formatted, int color = COLOR_BLUE);
+    void AddToListBox(int listBoxID, int dataID, CellData value, std::string formatted, int color = COLOR_BLUE);
     void AddToListBox(int listBoxID, int dataID, std::vector<std::string> data, int color = COLOR_BLUE);
-    void AddToListBox(int listBoxID, int dataID, std::vector<ItemContents> data, int color = COLOR_BLUE);
+    void AddToListBox(int listBoxID, int dataID, std::vector<FormattedCellData> data, int color = COLOR_BLUE);
     int GetSelectedItemFromList(int listBoxID);
     std::string GetSelectedTextFromList(int listBoxID); // MYR: For new message summary display in InterfaceProcesses.cpp
     int GetLastSelectedItemFromList(int listBoxID);

--- a/src/engine/include/interface/cInterfaceWindow.h
+++ b/src/engine/include/interface/cInterfaceWindow.h
@@ -29,6 +29,8 @@
 #include "interface/cSurface.h"
 #include <stack>
 
+#include "widgets/cListBox.h"
+
 class cImageItem;
 class cButton;
 class cEditBox;
@@ -93,7 +95,9 @@ public:
 
     // List Boxes
     void AddToListBox(int listBoxID, int dataID, std::string data, int color = COLOR_BLUE);
+    void AddToListBox(int listBoxID, int dataID, ItemData value, std::string formatted, int color = COLOR_BLUE);
     void AddToListBox(int listBoxID, int dataID, std::vector<std::string> data, int color = COLOR_BLUE);
+    void AddToListBox(int listBoxID, int dataID, std::vector<ItemContents> data, int color = COLOR_BLUE);
     int GetSelectedItemFromList(int listBoxID);
     std::string GetSelectedTextFromList(int listBoxID); // MYR: For new message summary display in InterfaceProcesses.cpp
     int GetLastSelectedItemFromList(int listBoxID);

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -24,79 +24,14 @@
 #include <vector>
 #include <functional>
 #include <SDL_keyboard.h>
-#include <boost/variant.hpp>
 
 #include "interface/cInterfaceObject.h"
 #include "interface/cFont.h"
 #include "interface/cSurface.h"
 #include "interface/constants.h"
+#include "interface/TableCells.h"
 
 class cScrollBar;
-
-/// An error type for our cell data.
-///
-/// Currently this is a singleton type (so all errors are effectively
-/// the same).
-struct Error
-{
-   constexpr friend bool operator==(Error, Error) { return true;}
-   constexpr friend bool operator< (Error, Error) { return false;}
-};
-
-/// Data that we want to put in a \c cListBox cell.
-using CellData = boost::variant<std::string, int, bool, Error>;
-
-/// Cell data with attached formatting.
-struct FormattedCellData {
-   CellData val_;
-   std::string fmt_;
-};
-
-/// Create a formatted cell with text.
-inline
-FormattedCellData mk_text(std::string val)
-{
-   auto str = val;
-   return FormattedCellData{std::move(val), std::move(str)};
-}
-
-/// Create a formatted cell with an error.
-inline
-FormattedCellData mk_error(std::string errtext)
-{
-   return FormattedCellData{Error{}, std::move(errtext)};
-}
-
-/// Create a formatted cell with a numeric value.
-inline
-FormattedCellData mk_num(int val)
-{
-   return FormattedCellData{val, std::to_string(val)};
-};
-
-/// Create a formatted "Yes/No" cell.
-inline
-FormattedCellData mk_yesno(bool val)
-{
-   return FormattedCellData{val, val ? "Yes" : "No"};
-};
-
-/// Create a formatted cell with a numeric percentage.
-inline
-FormattedCellData mk_percent(int val)
-{
-   return FormattedCellData{val, std::to_string(val) + '%'};
-};
-
-/// Create a formatted cell with a health value.
-inline
-FormattedCellData mk_health(int val)
-{
-   if(val <= 0)
-      return FormattedCellData{val, "DEAD"};
-   else
-      return FormattedCellData{val, std::to_string(val) + '%'};
-};
 
 struct cListItem
 {

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -71,33 +71,9 @@ struct cListItem
     std::vector<cSurface> m_PreRendered;
 };
 
-#if 1 // TODO: Remove `ColumnType`
-enum class ColumnType {
-                       String = 0, // also the fallback choice
-                       Numeric,
-                       Age,     // numeric, or '???'
-};
-#endif
-
-#if 1 // TODO: Remove `ColumnType`
-inline
-ColumnType from_string(std::string const& str)
-{
-  if(str == "String")
-    return ColumnType::String;
-  else if(str == "Numeric")
-    return ColumnType::Numeric;
-  else if(str == "Age")
-    return ColumnType::Age;
-  else
-    return ColumnType{};
-}
-#endif
-
 struct sColumnData {
     std::string name;           // internal name of the column
     std::string header;         // displayed header of the column
-    ColumnType type;            // type of the column (chooses sorting order)
     int offset = -1;            // draw offset
     int width = -1;             // width of the column
     int sort;                   // sorting index, in case display order does not correspond to internal data order.
@@ -158,7 +134,7 @@ public:
 
     std::string m_HeaderClicked;                    // set to m_ColumnName value of a header that has just been clicked; otherwise empty
 
-    void DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<ColumnType> types, std::vector<int> offset, std::vector<bool> skip);  // define column layout
+    void DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<int> offset, std::vector<bool> skip);  // define column layout
     void SetColumnSort(const std::vector<std::string>& column_name);    // Update column sorting based on expected default order
     void AddElement(int ID, std::vector<ItemContents> data, int color);
     void SetElementText(int ID, std::string data[], int columns);

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -40,6 +40,40 @@ struct ItemContents {
    std::string fmt_;
 };
 
+inline
+ItemContents mk_text(std::string val)
+{
+   auto str = val;
+   return ItemContents{std::move(val), std::move(str)};
+}
+
+inline
+ItemContents mk_num(int val)
+{
+   return ItemContents{val, std::to_string(val)};
+};
+
+inline
+ItemContents mk_yesno(bool val)
+{
+   return ItemContents{val, val ? "Yes" : "No"};
+};
+
+inline
+ItemContents mk_percent(int val)
+{
+   return ItemContents{val, std::to_string(val) + '%'};
+};
+
+inline
+ItemContents mk_health(int val)
+{
+   if(val <= 0)
+      return ItemContents{val, "DEAD"};
+   else
+      return ItemContents{val, std::to_string(val) + '%'};
+};
+
 struct cListItem
 {
     int m_Color = 0;

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -33,8 +33,18 @@
 
 class cScrollBar;
 
+/// An error type for our cell data.
+///
+/// Currently this is a singleton type (so all errors are effectively
+/// the same).
+struct Error
+{
+   constexpr friend bool operator==(Error, Error) { return true;}
+   constexpr friend bool operator< (Error, Error) { return false;}
+};
+
 /// Data that we want to put in a \c cListBox cell.
-using CellData = boost::variant<std::string, int, bool>;
+using CellData = boost::variant<std::string, int, bool, Error>;
 
 /// Cell data with attached formatting.
 struct FormattedCellData {
@@ -48,6 +58,13 @@ FormattedCellData mk_text(std::string val)
 {
    auto str = val;
    return FormattedCellData{std::move(val), std::move(str)};
+}
+
+/// Create a formatted cell with an error.
+inline
+FormattedCellData mk_error(std::string errtext)
+{
+   return FormattedCellData{Error{}, std::move(errtext)};
 }
 
 /// Create a formatted cell with a numeric value.

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -33,23 +33,7 @@
 
 class cScrollBar;
 
-// Age is unknown, as a singleton type.
-struct AgeUnknown {
-   friend constexpr bool operator==(AgeUnknown, AgeUnknown) { return true; }
-   friend constexpr bool operator< (AgeUnknown, AgeUnknown) { return false; }
-};
-
-using Age = boost::variant<size_t, AgeUnknown>;
-
-// Health is "DEAD", as a singleton type
-struct HealthDead {
-   friend constexpr bool operator==(HealthDead, HealthDead) { return true; }
-   friend constexpr bool operator< (HealthDead, HealthDead) { return false; }
-};
-
-using Health = boost::variant<HealthDead, size_t>;
-
-using ItemData = boost::variant<std::string, int, Age, Health>;
+using ItemData = boost::variant<std::string, int, bool>;
 
 struct ItemContents {
    ItemData val_;

--- a/src/engine/include/widgets/cListBox.h
+++ b/src/engine/include/widgets/cListBox.h
@@ -33,45 +33,52 @@
 
 class cScrollBar;
 
-using ItemData = boost::variant<std::string, int, bool>;
+/// Data that we want to put in a \c cListBox cell.
+using CellData = boost::variant<std::string, int, bool>;
 
-struct ItemContents {
-   ItemData val_;
+/// Cell data with attached formatting.
+struct FormattedCellData {
+   CellData val_;
    std::string fmt_;
 };
 
+/// Create a formatted cell with text.
 inline
-ItemContents mk_text(std::string val)
+FormattedCellData mk_text(std::string val)
 {
    auto str = val;
-   return ItemContents{std::move(val), std::move(str)};
+   return FormattedCellData{std::move(val), std::move(str)};
 }
 
+/// Create a formatted cell with a numeric value.
 inline
-ItemContents mk_num(int val)
+FormattedCellData mk_num(int val)
 {
-   return ItemContents{val, std::to_string(val)};
+   return FormattedCellData{val, std::to_string(val)};
 };
 
+/// Create a formatted "Yes/No" cell.
 inline
-ItemContents mk_yesno(bool val)
+FormattedCellData mk_yesno(bool val)
 {
-   return ItemContents{val, val ? "Yes" : "No"};
+   return FormattedCellData{val, val ? "Yes" : "No"};
 };
 
+/// Create a formatted cell with a numeric percentage.
 inline
-ItemContents mk_percent(int val)
+FormattedCellData mk_percent(int val)
 {
-   return ItemContents{val, std::to_string(val) + '%'};
+   return FormattedCellData{val, std::to_string(val) + '%'};
 };
 
+/// Create a formatted cell with a health value.
 inline
-ItemContents mk_health(int val)
+FormattedCellData mk_health(int val)
 {
    if(val <= 0)
-      return ItemContents{val, "DEAD"};
+      return FormattedCellData{val, "DEAD"};
    else
-      return ItemContents{val, std::to_string(val) + '%'};
+      return FormattedCellData{val, std::to_string(val) + '%'};
 };
 
 struct cListItem
@@ -81,7 +88,7 @@ struct cListItem
 
     // The text to display, and data to sort on; up to LISTBOX_COLUMNS
     // number of columns (+1 is used for "original sort" slot)
-    std::vector<ItemContents> m_Data;
+    std::vector<FormattedCellData> m_Data;
 
     int m_ID;    // the id for the item
     std::unique_ptr<SDL_Color> m_TextColor;
@@ -154,7 +161,7 @@ public:
 
     void DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<int> offset, std::vector<bool> skip);  // define column layout
     void SetColumnSort(const std::vector<std::string>& column_name);    // Update column sorting based on expected default order
-    void AddElement(int ID, std::vector<ItemContents> data, int color);
+    void AddElement(int ID, std::vector<FormattedCellData> data, int color);
     void SetElementText(int ID, std::string data[], int columns);
     void SetElementColumnText(int ID, std::string data, const std::string& column);
     void SetElementTextColor(int ID, SDL_Color text_color);

--- a/src/engine/interface/cInterfaceWindow.cpp
+++ b/src/engine/interface/cInterfaceWindow.cpp
@@ -445,15 +445,15 @@ void cInterfaceWindow::SetSelectedItemText(int listBoxID, int itemID, string dat
 
 void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, string text, int color)
 {
-    ItemData value = text;
+    CellData value = text;
     AddToListBox(listBoxID, dataID,
-                 std::vector<ItemContents>{{std::move(value), std::move(text)}},
+                 std::vector<FormattedCellData>{{std::move(value), std::move(text)}},
                  color);
 }
 
-void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, ItemData value, string formatted, int color)
+void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, CellData value, string formatted, int color)
 {
-    AddToListBox(listBoxID, dataID, std::vector<ItemContents>{{std::move(value), std::move(formatted)}}, color);
+    AddToListBox(listBoxID, dataID, std::vector<FormattedCellData>{{std::move(value), std::move(formatted)}}, color);
 }
 
 void cInterfaceWindow::SetSelectedItemText(int listBoxID, int itemID, string data[], int columns)
@@ -478,18 +478,17 @@ void cInterfaceWindow::FillSortedIDList(int listBoxID, vector<int>& id_vec, int&
 
 void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, std::vector<std::string> data, int color)
 {
-   std::vector<ItemContents> expanded_data;
+   std::vector<FormattedCellData> expanded_data;
    expanded_data.reserve(data.size());
 
    std::transform(begin(data), end(data),
                   std::back_inserter(expanded_data),
-                  [](std::string const& str) -> ItemContents
-                  { return {str, str}; });
+                  [](std::string const& str) { return mk_text(str); });
 
    AddToListBox(listBoxID, dataID, expanded_data, color);
 }
 
-void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, std::vector<ItemContents> data, int color)
+void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, std::vector<FormattedCellData> data, int color)
 {
     if(listBoxID < 0) {
         g_LogFile.error("interface", "Trying to access invalid ListBox");

--- a/src/engine/interface/cInterfaceWindow.cpp
+++ b/src/engine/interface/cInterfaceWindow.cpp
@@ -443,9 +443,17 @@ void cInterfaceWindow::SetSelectedItemText(int listBoxID, int itemID, string dat
     GetListBox(listBoxID)->SetElementText(itemID, data);
 }
 
-void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, string data, int color)
+void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, string text, int color)
 {
-    AddToListBox(listBoxID, dataID, std::vector<std::string>{std::move(data)}, color);
+    ItemData value = text;
+    AddToListBox(listBoxID, dataID,
+                 std::vector<ItemContents>{{std::move(value), std::move(text)}},
+                 color);
+}
+
+void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, ItemData value, string formatted, int color)
+{
+    AddToListBox(listBoxID, dataID, std::vector<ItemContents>{{std::move(value), std::move(formatted)}}, color);
 }
 
 void cInterfaceWindow::SetSelectedItemText(int listBoxID, int itemID, string data[], int columns)
@@ -469,6 +477,19 @@ void cInterfaceWindow::FillSortedIDList(int listBoxID, vector<int>& id_vec, int&
 }
 
 void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, std::vector<std::string> data, int color)
+{
+   std::vector<ItemContents> expanded_data;
+   expanded_data.reserve(data.size());
+
+   std::transform(begin(data), end(data),
+                  std::back_inserter(expanded_data),
+                  [](std::string const& str) -> ItemContents
+                  { return {str, str}; });
+
+   AddToListBox(listBoxID, dataID, expanded_data, color);
+}
+
+void cInterfaceWindow::AddToListBox(int listBoxID, int dataID, std::vector<ItemContents> data, int color)
 {
     if(listBoxID < 0) {
         g_LogFile.error("interface", "Trying to access invalid ListBox");

--- a/src/engine/interface/cInterfaceWindowXML.cpp
+++ b/src/engine/interface/cInterfaceWindowXML.cpp
@@ -268,7 +268,6 @@ void cInterfaceWindowXML::read_listbox_definition(tinyxml2::XMLElement& el)
     std::vector<int> column_offset;
     std::vector<bool> column_skip;
     std::vector<std::string> column_name, column_header;
-    std::vector<ColumnType> column_type;
     for (auto& sub_el : IterateChildElements(el))
     {
         std::string tag = sub_el.Value();
@@ -280,11 +279,9 @@ void cInterfaceWindowXML::read_listbox_definition(tinyxml2::XMLElement& el)
             int offset = sub_el.IntAttribute("Offset", 0);
             bool skip = sub_el.BoolAttribute("Skip", false);
             std::string header = GetDefaultedStringAttribute(sub_el, "Header", name.c_str());
-            auto type = from_string(GetDefaultedStringAttribute(sub_el, "Type", "(default)"));
 
             column_name.push_back(std::move(name));
             column_header.push_back(std::move(header));
-            column_type.push_back(type);
             column_offset.push_back(offset);
             column_skip.push_back(skip);
         }
@@ -295,7 +292,7 @@ void cInterfaceWindowXML::read_listbox_definition(tinyxml2::XMLElement& el)
     }
     // If we have columns defined, go ahead and give the listbox all the gory details
     if (!column_name.empty())
-      box->DefineColumns(column_name, column_header, column_type,
+      box->DefineColumns(column_name, column_header,
                          column_offset, column_skip);
 }
 

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -53,7 +53,6 @@ cListBox::cListBox(cInterfaceWindow* parent, int ID, int x, int y, int width, in
     m_LastSelected = m_Items.end();
 
     DefineColumns(std::vector<std::string>(1), std::vector<std::string>(1),
-                  std::vector<ColumnType>(1),
                   std::vector<int>(1), std::vector<bool>(1));
     SDL_Rect dest_rect;
 
@@ -640,7 +639,7 @@ void cListBox::AddElement(int ID, std::vector<ItemContents> data, int color)
         m_ScrollBar->m_ItemsTotal = m_NumElements;
 }
 
-void cListBox::DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<ColumnType> types, std::vector<int> offset, std::vector<bool> skip)
+void cListBox::DefineColumns(std::vector<std::string> name, std::vector<std::string> header, std::vector<int> offset, std::vector<bool> skip)
 {
     m_Columns.clear();
 
@@ -652,7 +651,7 @@ void cListBox::DefineColumns(std::vector<std::string> name, std::vector<std::str
         int left = offset[i];
         int right = i == name.size() - 1 ? m_eWidth : offset[i + 1];
         auto gfx = m_Font.RenderText(header[i]);
-        m_Columns.emplace_back(sColumnData{std::move(name[i]), std::move(header[i]), types[i], left, right - left, i, skip[i], gfx});
+        m_Columns.emplace_back(sColumnData{std::move(name[i]), std::move(header[i]), left, right - left, i, skip[i], gfx});
     }
     m_Font.SetFontBold(false);
 

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -613,7 +613,7 @@ void cListBox::SetElementTextColor(int ID, SDL_Color text_color)
         }
     }
 }
-void cListBox::AddElement(int ID, std::vector<ItemContents> data, int color)
+void cListBox::AddElement(int ID, std::vector<FormattedCellData> data, int color)
 {
     m_Items.emplace_back();
     auto& newItem = m_Items.back();

--- a/src/engine/widgets/cListBox.cpp
+++ b/src/engine/widgets/cListBox.cpp
@@ -523,7 +523,7 @@ const std::string& cListBox::GetSelectedText()
     if (m_LastSelected == m_Items.end())
         return empty;
     else
-        return m_LastSelected->m_Data.front();
+        return m_LastSelected->m_Data.front().fmt_;
 }
 
 bool cListBox::IsSelected()
@@ -554,13 +554,14 @@ void cListBox::SetElementText(int ID, std::string data[], int columns)
         if (item.m_ID == ID)
         {
             for (int i = 0; i < columns; i++) {
-                item.m_Data[i] = data[i];
+                item.m_Data[i].val_ = data[i];
+                item.m_Data[i].fmt_ = data[i];
                 if(item.m_TextColor) {
                     m_Font.SetColor(item.m_TextColor->r, item.m_TextColor->g, item.m_TextColor->b);
                 } else {
                     m_Font.SetColor(g_ListBoxTextColor.r, g_ListBoxTextColor.g, g_ListBoxTextColor.b);
                 }
-                item.m_PreRendered[i] = m_Font.RenderText(item.m_Data[i]);
+                item.m_PreRendered[i] = m_Font.RenderText(item.m_Data[i].fmt_);
             }
             break;
         }
@@ -591,7 +592,8 @@ void cListBox::SetElementColumnText(int ID, std::string data, const std::string&
             }
             item.m_PreRendered[column_id] = m_Font.RenderText(data);
 
-            item.m_Data[column_id] = std::move(data);
+            item.m_Data[column_id].val_ = data;
+            item.m_Data[column_id].fmt_ = std::move(data);
             break;
         }
     }
@@ -606,13 +608,13 @@ void cListBox::SetElementTextColor(int ID, SDL_Color text_color)
             item.m_TextColor = std::make_unique<SDL_Color>(text_color);
             m_Font.SetColor(text_color.r, text_color.g, text_color.b);
             for(unsigned i = 0; i < item.m_Data.size(); ++i) {
-                item.m_PreRendered[i] = m_Font.RenderText(item.m_Data[i]);
+                item.m_PreRendered[i] = m_Font.RenderText(item.m_Data[i].fmt_);
             }
             break;
         }
     }
 }
-void cListBox::AddElement(int ID, std::vector<std::string> data, int color)
+void cListBox::AddElement(int ID, std::vector<ItemContents> data, int color)
 {
     m_Items.emplace_back();
     auto& newItem = m_Items.back();
@@ -623,7 +625,7 @@ void cListBox::AddElement(int ID, std::vector<std::string> data, int color)
     for(std::size_t i = 0; i < newItem.m_Data.size(); ++i) {
         /// TODO add ability to use reference to existing font with new text
         m_Font.SetColor(g_ListBoxTextColor.r, g_ListBoxTextColor.g, g_ListBoxTextColor.b);
-        auto gfx = m_Font.RenderText(newItem.m_Data[i]);
+        auto gfx = m_Font.RenderText(newItem.m_Data[i].fmt_);
         newItem.m_PreRendered.push_back(std::move(gfx));
     }
 
@@ -784,50 +786,27 @@ void cListBox::UnSortList()
 namespace {
   enum class Direction { Ascending, Descending };
 
-  // Fetches the value of `item` at column `col_id`, and returns it as
-  // some type with an `operator<()` that gives us the sorting order
-  // we want.
-  template<ColumnType>
-  auto get_value(cListItem const& item, int col_id);
-
-  template<>
-  auto get_value<ColumnType::Numeric>(cListItem const& item, int col_id)
+  // Sorts `list` by column `col_id`.
+  void do_sort(cListBox::item_list_t& list, int col_id, Direction dir) noexcept
   {
-    return std::stoi(item.m_Data[col_id]);
-  }
+    auto get_value
+       = [col_id] (cListItem const& item) noexcept {
+            return item.m_Data[col_id].val_;
+         };
 
-  template<>
-  auto get_value<ColumnType::Age>(cListItem const& item, int col_id)
-  {
-    if(item.m_Data[col_id] == "???")
-      return std::numeric_limits<int>::max();
-    else
-      return std::stoi(item.m_Data[col_id]);
-  }
-
-  template<>
-  auto get_value<ColumnType::String>(cListItem const& item, int col_id)
-  {
-    return item.m_Data[col_id];
-  }
-
-  // Sorts `list` by column `col_id` of type `col_type`.
-  template<ColumnType col_type>
-  void do_sort(cListBox::item_list_t& list, int col_id, Direction dir)
-  {
     auto less_than
-      = [col_id](cListItem const& a, cListItem const& b) {
-	  return get_value<col_type>(a, col_id) < get_value<col_type>(b, col_id);
+      = [get_value](cListItem const& a, cListItem const& b) noexcept {
+	  return get_value(a) < get_value(b);
 	};
 
     switch(dir) {
     case Direction::Ascending:
-      list.sort([less_than](const cListItem& a, const cListItem& b) {
+      list.sort([less_than](const cListItem& a, const cListItem& b) noexcept {
 		  return less_than(a, b);
 		});
       break;
     case Direction::Descending:
-      list.sort([less_than](const cListItem& a, const cListItem& b) {
+      list.sort([less_than](const cListItem& a, const cListItem& b) noexcept {
 		  return less_than(b, a);
 		});
       break;
@@ -859,23 +838,8 @@ void cListBox::SortByColumn(std::string ColumnName, bool Descending)
     // `m_LastSelected` will effectively be carried along to the
     // target element's new position.
 
-    /// TODO make sure this cannot throw.
-    try {
-        auto direction = Descending ? Direction::Descending : Direction::Ascending;
-        switch (m_Columns[col_ref].type) {
-            case ColumnType::Numeric:
-                do_sort<ColumnType::Numeric>(m_Items, col_id, direction);
-                break;
-            case ColumnType::Age:
-                do_sort<ColumnType::Age>(m_Items, col_id, direction);
-                break;
-            case ColumnType::String:
-                do_sort<ColumnType::String>(m_Items, col_id, direction);
-                break;
-        }
-    } catch (const std::exception& error) {
-        window_manager().PushError(std::string("Error during sorting: ") + error.what());
-    }
+    auto direction = Descending ? Direction::Descending : Direction::Ascending;
+    do_sort(m_Items, col_id, direction);
 
     UpdatePositionsAfterSort();
 

--- a/src/game/buildings/cDungeon.cpp
+++ b/src/game/buildings/cDungeon.cpp
@@ -280,7 +280,7 @@ void cDungeon::RemoveCust(sDungeonCust* cust)
     m_NumCusts--;
 }
 
-void cDungeon::OutputGirlRow(int i, std::vector<std::string>& Data, const std::vector<std::string>& columnNames)
+void cDungeon::OutputGirlRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames)
 {
     Data.resize(columnNames.size());
     int tmp = 0;
@@ -290,7 +290,7 @@ void cDungeon::OutputGirlRow(int i, std::vector<std::string>& Data, const std::v
             for (unsigned int x = 0; x < columnNames.size(); ++x)
             {
                 //for each column, write out the statistic that goes in it
-                current.OutputGirlDetailString(Data[x], columnNames[x]);
+                Data[x] = current.OutputGirlDetail(columnNames[x]);
             }
             break;
         };
@@ -298,53 +298,66 @@ void cDungeon::OutputGirlRow(int i, std::vector<std::string>& Data, const std::v
     }
 }
 
-void sDungeonGirl::OutputGirlDetailString(std::string& Data, const std::string& detailName)
+/// Given a name of a detail (stat, skill, trait, etc.), returns its
+/// value as itself (`.val_`) and as a formatted string (`.fmt_`).
+ItemContents sDungeonGirl::OutputGirlDetail(const std::string& detailName) const
 {
-    //given a statistic name, set a string to a value that represents that statistic
-    static std::stringstream ss;
-    ss.str("");
-    if (detailName == "Rebelliousness")    // `J` Dungeon "Matron" can be a Torturer from any brothel
+    auto mk_text = [](std::string str) {
+                      return ItemContents{str, str};
+                   };
+    auto mk_num = [](int val) {
+                     return ItemContents{val, std::to_string(val)};
+                  };
+    auto mk_yesno = [](bool val) {
+                       return ItemContents{val, val ? "Yes" : "No"};
+                      };
+
+    if (detailName == "Rebelliousness")
     {
-        ss << cGirls::GetRebelValue(*m_Girl, random_girl_on_job(g_Game->buildings(), JOB_TORTURER, false) != nullptr);
+        // `J` Dungeon "Matron" can be a Torturer from any brothel
+        bool has_torturer = (random_girl_on_job(g_Game->buildings(), JOB_TORTURER, false) != nullptr);
+        return mk_num(cGirls::GetRebelValue(*m_Girl, has_torturer));
     }
     else if (detailName == "Reason")
     {
         switch (m_Reason)
         {
-        case DUNGEON_GIRLCAPTURED:                ss << "Newly Captured.";                    break;
-        case DUNGEON_GIRLKIDNAPPED:                ss << "Taken from her family.";            break;
-        case DUNGEON_GIRLWHIM:                    ss << "Your whim.";                        break;
-        case DUNGEON_GIRLSTEAL:                    ss << "Not reporting true earnings.";        break;
-        case DUNGEON_GIRLRUNAWAY:                ss << "Ran away and re-captured.";            break;
-        case DUNGEON_NEWSLAVE:                    ss << "This is a new slave.";                break;
-        case DUNGEON_NEWGIRL:                    ss << "This is a new girl.";                break;
-        case DUNGEON_KID:                        ss << "Child of one of your girls.";        break;
-        case DUNGEON_NEWARENA:                    ss << "This is a girl won in the arena.";    break;
-        case DUNGEON_RECRUITED:                    ss << "This girl was recruited for you.";    break;
+           case DUNGEON_GIRLCAPTURED:     return mk_text("Newly Captured.");
+           case DUNGEON_GIRLKIDNAPPED:    return mk_text("Taken from her family.");
+           case DUNGEON_GIRLWHIM:         return mk_text("Your whim.");
+           case DUNGEON_GIRLSTEAL:        return mk_text("Not reporting true earnings.");
+           case DUNGEON_GIRLRUNAWAY:      return mk_text("Ran away and re-captured.");
+           case DUNGEON_NEWSLAVE:         return mk_text("This is a new slave.");
+           case DUNGEON_NEWGIRL:          return mk_text("This is a new girl.");
+           case DUNGEON_KID:              return mk_text("Child of one of your girls.");
+           case DUNGEON_NEWARENA:         return mk_text("This is a girl won in the arena.");
+           case DUNGEON_RECRUITED:        return mk_text("This girl was recruited for you.");
+           default:                       return mk_text("(error)");
         }
     }
-    else if (detailName == "Duration")            { ss << m_Weeks; }
-    else if (detailName == "Feeding")            { ss << ((m_Feeding) ? "Yes" : "No"); }
-    else if (detailName == "Tortured")            { ss << ((m_Girl->m_Tort) ? "Yes" : "No"); }
+    else if (detailName == "Duration")    return mk_num(m_Weeks);
+    else if (detailName == "Feeding")     return mk_yesno(m_Feeding);
+    else if (detailName == "Tortured")    return mk_yesno(m_Girl->m_Tort);
     else if (detailName == "Kidnapped")
     {
         // TODO (traits) figure out something here!
-        /*
+#if 0
+        std::ostringstream ss;
+
         auto info = m_Girl->raw_traits().get_trait_info("Kidnapped");
         if (info.trait && info.remaining_time > 0) ss << info.remaining_time;
         else ss << "-";
-        */
+#else
+        return mk_text("-");
+#endif
     }
     else
     {
-        m_Girl->OutputGirlDetailString(Data, detailName);
-        return;
+        return m_Girl->OutputGirlDetail(detailName);
     }
-
-    Data = ss.str();
 }
 
-void cDungeon::OutputCustRow(int i, std::vector<std::string>& Data, const std::vector<std::string>& columnNames)
+void cDungeon::OutputCustRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames)
 {
     Data.resize(columnNames.size());
     sDungeonCust* cust = m_Custs;
@@ -360,36 +373,48 @@ void cDungeon::OutputCustRow(int i, std::vector<std::string>& Data, const std::v
         for (unsigned int x = 0; x < columnNames.size(); ++x)
         {
             //for each column, write out the statistic that goes in it
-            cust->OutputCustDetailString(Data[x], columnNames[x]);
+            Data[x] = cust->OutputCustDetail(columnNames[x]);
         }
     }
 }
 
-void sDungeonCust::OutputCustDetailString(std::string& Data, const std::string& detailName)
+/// Given a name of a detail (stat, skill, trait, etc.), returns its
+/// value as itself (`.val_`) and as a formatted string (`.fmt_`).
+ItemContents sDungeonCust::OutputCustDetail(const std::string& detailName) const
 {
-    //given a statistic name, set a string to a value that represents that statistic
-    static std::stringstream ss;
-    ss.str("");
-    if (detailName == "Name")                    { ss << "Customer"; }
-    else if (detailName == "Health")    { if (m_Health <= 0) ss << "DEAD"; else ss << m_Health << "%"; }
+    auto mk_text = [](std::string str) {
+                      return ItemContents{str, str};
+                   };
+    auto mk_num = [](int val) {
+                     return ItemContents{val, std::to_string(val)};
+                  };
+    auto mk_yesno = [](bool val) {
+                       return ItemContents{val, val ? "Yes" : "No"};
+                      };
+    auto mk_health = [](int val) {
+                        if(val <= 0)
+                           return ItemContents{val, "DEAD"};
+                        else
+                           return ItemContents{val, std::to_string(val) + '%'};
+                     };
+
+    if (detailName == "Name")           return mk_text("Customer");
+    else if (detailName == "Health")    return mk_health(m_Health);
     else if (detailName == "Reason")
     {
         switch (m_Reason)
         {
-        case DUNGEON_CUSTNOPAY:            ss << "Not paying.";            break;
-        case DUNGEON_CUSTBEATGIRL:        ss << "Beating your girls.";    break;
-        case DUNGEON_CUSTSPY:            ss << "Being a rival's spy.";    break;
-        case DUNGEON_RIVAL:                ss << "Is a rival.";            break;
+        case DUNGEON_CUSTNOPAY:         return mk_text("Not paying.");
+        case DUNGEON_CUSTBEATGIRL:      return mk_text("Beating your girls.");
+        case DUNGEON_CUSTSPY:           return mk_text("Being a rival's spy.");
+        case DUNGEON_RIVAL:             return mk_text("Is a rival.");
+        default:                        return mk_text("(error)");
         }
     }
-    else if (detailName == "Duration")            { ss << (int)m_Weeks; }
-    else if (detailName == "Feeding")            { ss << ((m_Feeding) ? "Yes" : "No"); }
-    else if (detailName == "Tortured")            { ss << ((m_Tort) ? "Yes" : "No"); }
-    else
-    {
-        ss << "---";
-    }
-    Data = ss.str();
+    else if (detailName == "Duration")  return mk_num((int)m_Weeks);
+    else if (detailName == "Feeding")   return mk_yesno(m_Feeding);
+    else if (detailName == "Tortured")  return mk_yesno(m_Tort);
+    else                                return mk_text("---");
 }
 
 sDungeonGirl* cDungeon::GetGirl(int i)

--- a/src/game/buildings/cDungeon.cpp
+++ b/src/game/buildings/cDungeon.cpp
@@ -290,7 +290,7 @@ void cDungeon::OutputGirlRow(int i, std::vector<FormattedCellData>& Data, const 
             for (unsigned int x = 0; x < columnNames.size(); ++x)
             {
                 //for each column, write out the statistic that goes in it
-                Data[x] = current.OutputGirlDetail(columnNames[x]);
+                Data[x] = current.GetDetail(columnNames[x]);
             }
             break;
         };
@@ -300,7 +300,7 @@ void cDungeon::OutputGirlRow(int i, std::vector<FormattedCellData>& Data, const 
 
 /// Given a name of a detail (stat, skill, trait, etc.), returns its
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
-FormattedCellData sDungeonGirl::OutputGirlDetail(const std::string& detailName) const
+FormattedCellData sDungeonGirl::GetDetail(const std::string& detailName) const
 {
     if (detailName == "Rebelliousness")
     {
@@ -343,7 +343,7 @@ FormattedCellData sDungeonGirl::OutputGirlDetail(const std::string& detailName) 
     }
     else
     {
-        return m_Girl->OutputGirlDetail(detailName);
+        return m_Girl->GetDetail(detailName);
     }
 }
 
@@ -363,14 +363,14 @@ void cDungeon::OutputCustRow(int i, std::vector<FormattedCellData>& Data, const 
         for (unsigned int x = 0; x < columnNames.size(); ++x)
         {
             //for each column, write out the statistic that goes in it
-            Data[x] = cust->OutputCustDetail(columnNames[x]);
+            Data[x] = cust->GetDetail(columnNames[x]);
         }
     }
 }
 
 /// Given a name of a detail (stat, skill, trait, etc.), returns its
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
-FormattedCellData sDungeonCust::OutputCustDetail(const std::string& detailName) const
+FormattedCellData sDungeonCust::GetDetail(const std::string& detailName) const
 {
     if (detailName == "Name")           return mk_text("Customer");
     else if (detailName == "Health")    return mk_health(m_Health);

--- a/src/game/buildings/cDungeon.cpp
+++ b/src/game/buildings/cDungeon.cpp
@@ -302,16 +302,6 @@ void cDungeon::OutputGirlRow(int i, std::vector<ItemContents>& Data, const std::
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
 ItemContents sDungeonGirl::OutputGirlDetail(const std::string& detailName) const
 {
-    auto mk_text = [](std::string str) {
-                      return ItemContents{str, str};
-                   };
-    auto mk_num = [](int val) {
-                     return ItemContents{val, std::to_string(val)};
-                  };
-    auto mk_yesno = [](bool val) {
-                       return ItemContents{val, val ? "Yes" : "No"};
-                      };
-
     if (detailName == "Rebelliousness")
     {
         // `J` Dungeon "Matron" can be a Torturer from any brothel
@@ -382,22 +372,6 @@ void cDungeon::OutputCustRow(int i, std::vector<ItemContents>& Data, const std::
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
 ItemContents sDungeonCust::OutputCustDetail(const std::string& detailName) const
 {
-    auto mk_text = [](std::string str) {
-                      return ItemContents{str, str};
-                   };
-    auto mk_num = [](int val) {
-                     return ItemContents{val, std::to_string(val)};
-                  };
-    auto mk_yesno = [](bool val) {
-                       return ItemContents{val, val ? "Yes" : "No"};
-                      };
-    auto mk_health = [](int val) {
-                        if(val <= 0)
-                           return ItemContents{val, "DEAD"};
-                        else
-                           return ItemContents{val, std::to_string(val) + '%'};
-                     };
-
     if (detailName == "Name")           return mk_text("Customer");
     else if (detailName == "Health")    return mk_health(m_Health);
     else if (detailName == "Reason")

--- a/src/game/buildings/cDungeon.cpp
+++ b/src/game/buildings/cDungeon.cpp
@@ -280,7 +280,7 @@ void cDungeon::RemoveCust(sDungeonCust* cust)
     m_NumCusts--;
 }
 
-void cDungeon::OutputGirlRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames)
+void cDungeon::OutputGirlRow(int i, std::vector<FormattedCellData>& Data, const std::vector<std::string>& columnNames)
 {
     Data.resize(columnNames.size());
     int tmp = 0;
@@ -300,7 +300,7 @@ void cDungeon::OutputGirlRow(int i, std::vector<ItemContents>& Data, const std::
 
 /// Given a name of a detail (stat, skill, trait, etc.), returns its
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
-ItemContents sDungeonGirl::OutputGirlDetail(const std::string& detailName) const
+FormattedCellData sDungeonGirl::OutputGirlDetail(const std::string& detailName) const
 {
     if (detailName == "Rebelliousness")
     {
@@ -347,7 +347,7 @@ ItemContents sDungeonGirl::OutputGirlDetail(const std::string& detailName) const
     }
 }
 
-void cDungeon::OutputCustRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames)
+void cDungeon::OutputCustRow(int i, std::vector<FormattedCellData>& Data, const std::vector<std::string>& columnNames)
 {
     Data.resize(columnNames.size());
     sDungeonCust* cust = m_Custs;
@@ -370,7 +370,7 @@ void cDungeon::OutputCustRow(int i, std::vector<ItemContents>& Data, const std::
 
 /// Given a name of a detail (stat, skill, trait, etc.), returns its
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
-ItemContents sDungeonCust::OutputCustDetail(const std::string& detailName) const
+FormattedCellData sDungeonCust::OutputCustDetail(const std::string& detailName) const
 {
     if (detailName == "Name")           return mk_text("Customer");
     else if (detailName == "Health")    return mk_health(m_Health);

--- a/src/game/buildings/cDungeon.cpp
+++ b/src/game/buildings/cDungeon.cpp
@@ -322,7 +322,7 @@ FormattedCellData sDungeonGirl::OutputGirlDetail(const std::string& detailName) 
            case DUNGEON_KID:              return mk_text("Child of one of your girls.");
            case DUNGEON_NEWARENA:         return mk_text("This is a girl won in the arena.");
            case DUNGEON_RECRUITED:        return mk_text("This girl was recruited for you.");
-           default:                       return mk_text("(error)");
+           default:                       return mk_error("(error)");
         }
     }
     else if (detailName == "Duration")    return mk_num(m_Weeks);
@@ -382,13 +382,13 @@ FormattedCellData sDungeonCust::OutputCustDetail(const std::string& detailName) 
         case DUNGEON_CUSTBEATGIRL:      return mk_text("Beating your girls.");
         case DUNGEON_CUSTSPY:           return mk_text("Being a rival's spy.");
         case DUNGEON_RIVAL:             return mk_text("Is a rival.");
-        default:                        return mk_text("(error)");
+        default:                        return mk_error("(error)");
         }
     }
     else if (detailName == "Duration")  return mk_num((int)m_Weeks);
     else if (detailName == "Feeding")   return mk_yesno(m_Feeding);
     else if (detailName == "Tortured")  return mk_yesno(m_Tort);
-    else                                return mk_text("---");
+    else                                return mk_error("---");
 }
 
 sDungeonGirl* cDungeon::GetGirl(int i)

--- a/src/game/buildings/cDungeon.h
+++ b/src/game/buildings/cDungeon.h
@@ -29,7 +29,7 @@
 
 #include "cGirls.h"
 
-#include "widgets/cListBox.h"
+#include "interface/TableCells.h"
 
 class cGirlTorture;
 

--- a/src/game/buildings/cDungeon.h
+++ b/src/game/buildings/cDungeon.h
@@ -29,6 +29,8 @@
 
 #include "cGirls.h"
 
+#include "widgets/cListBox.h"
+
 class cGirlTorture;
 
 // Keeps track of customers in the dungeon
@@ -48,7 +50,8 @@ struct sDungeonCust
     sDungeonCust*   m_Next;
     sDungeonCust*   m_Prev;
     int             m_Health;
-    void OutputCustDetailString(std::string& Data, const std::string& detailName);
+
+    ItemContents OutputCustDetail(const std::string& detailName) const;
 };
 
 // Keeps track of girls in the dungeon
@@ -66,7 +69,8 @@ struct sDungeonGirl
 
     // customer data
     std::shared_ptr<sGirl> m_Girl;
-    void OutputGirlDetailString(std::string& Data, const std::string& detailName);
+
+    ItemContents OutputGirlDetail(const std::string& detailName) const;
 };
 
 
@@ -95,8 +99,8 @@ public:
     bool SendGirlToDungeon(std::shared_ptr<sGirl> girl);
     void AddGirl(std::shared_ptr<sGirl> girl, int reason);
     void AddCust(int reason, int numDaughters, bool hasWife);
-    void OutputGirlRow(int i, std::vector<std::string>& Data, const std::vector<std::string>& columnNames);
-    void OutputCustRow(int i, std::vector<std::string>& Data, const std::vector<std::string>& columnNames);
+    void OutputGirlRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames);
+    void OutputCustRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames);
     sDungeonGirl* GetGirl(int i);
     sDungeonGirl* GetGirlByName(std::string name);
     sDungeonCust* GetCust(int i);

--- a/src/game/buildings/cDungeon.h
+++ b/src/game/buildings/cDungeon.h
@@ -51,7 +51,7 @@ struct sDungeonCust
     sDungeonCust*   m_Prev;
     int             m_Health;
 
-    FormattedCellData OutputCustDetail(const std::string& detailName) const;
+    FormattedCellData GetDetail(const std::string& detailName) const;
 };
 
 // Keeps track of girls in the dungeon
@@ -70,7 +70,7 @@ struct sDungeonGirl
     // customer data
     std::shared_ptr<sGirl> m_Girl;
 
-    FormattedCellData OutputGirlDetail(const std::string& detailName) const;
+    FormattedCellData GetDetail(const std::string& detailName) const;
 };
 
 

--- a/src/game/buildings/cDungeon.h
+++ b/src/game/buildings/cDungeon.h
@@ -51,7 +51,7 @@ struct sDungeonCust
     sDungeonCust*   m_Prev;
     int             m_Health;
 
-    ItemContents OutputCustDetail(const std::string& detailName) const;
+    FormattedCellData OutputCustDetail(const std::string& detailName) const;
 };
 
 // Keeps track of girls in the dungeon
@@ -70,7 +70,7 @@ struct sDungeonGirl
     // customer data
     std::shared_ptr<sGirl> m_Girl;
 
-    ItemContents OutputGirlDetail(const std::string& detailName) const;
+    FormattedCellData OutputGirlDetail(const std::string& detailName) const;
 };
 
 
@@ -99,8 +99,8 @@ public:
     bool SendGirlToDungeon(std::shared_ptr<sGirl> girl);
     void AddGirl(std::shared_ptr<sGirl> girl, int reason);
     void AddCust(int reason, int numDaughters, bool hasWife);
-    void OutputGirlRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames);
-    void OutputCustRow(int i, std::vector<ItemContents>& Data, const std::vector<std::string>& columnNames);
+    void OutputGirlRow(int i, std::vector<FormattedCellData>& Data, const std::vector<std::string>& columnNames);
+    void OutputCustRow(int i, std::vector<FormattedCellData>& Data, const std::vector<std::string>& columnNames);
     sDungeonGirl* GetGirl(int i);
     sDungeonGirl* GetGirlByName(std::string name);
     sDungeonCust* GetCust(int i);

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -915,7 +915,7 @@ FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
         }
         else
         {
-            return mk_text("Error");
+            return mk_error("Error");
         }
     }
     else if (detailName.substr(0, 6) == "SKILL_")
@@ -928,7 +928,7 @@ FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
         }
         else
         {
-            return mk_text("Error");
+            return mk_error("Error");
         }
     }
     else if (detailName.substr(0, 6) == "TRAIT_")
@@ -946,7 +946,7 @@ FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
         }
         else
         {
-            return mk_text("Error");
+            return mk_error("Error");
         }
     }
     else if (detailName == "is_pregnant")
@@ -1013,7 +1013,7 @@ FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
     else if (detailName == "SkillAverage")
         return mk_num((int)cGirls::GetAverageOfAllSkills(*this));
     else
-        return mk_text("Not found");
+        return mk_error("Not found");
 }
 
 /// Builds the detail value for jobs and job-like activities.

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -836,13 +836,13 @@ bool sGirl::was_resting() const
 
 /// Given a name of a detail (stat, skill, trait, etc.), returns its
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
-ItemContents sGirl::OutputGirlDetail(const std::string& detailName) const
+FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
 {
     auto mk_age = [](int val) {
                      if(val == 100)
-                        return ItemContents{val, "???"};
+                        return FormattedCellData{val, "???"};
                      else
-                        return ItemContents{val, std::to_string(val)};
+                        return FormattedCellData{val, std::to_string(val)};
                   };
 
     /* */if (detailName == "Name")     return mk_text(FullName());
@@ -1019,7 +1019,7 @@ ItemContents sGirl::OutputGirlDetail(const std::string& detailName) const
 /// Builds the detail value for jobs and job-like activities.
 ///
 /// \param detailName Either "DayJob" or "NightJob".
-ItemContents sGirl::OutputGirlDetail_Job(std::string const& detailName) const
+FormattedCellData sGirl::OutputGirlDetail_Job(std::string const& detailName) const
 {
    bool interrupted = false;    // `J` added
    if (m_YesterDayJob != m_DayJob &&

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -838,30 +838,12 @@ bool sGirl::was_resting() const
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
 ItemContents sGirl::OutputGirlDetail(const std::string& detailName) const
 {
-    auto mk_text = [](std::string str) {
-                      return ItemContents{str, str};
-                   };
-    auto mk_num = [](int val) {
-                     return ItemContents{val, std::to_string(val)};
+    auto mk_age = [](int val) {
+                     if(val == 100)
+                        return ItemContents{val, "???"};
+                     else
+                        return ItemContents{val, std::to_string(val)};
                   };
-    auto mk_health = [](int val) {
-                        if(val <= 0)
-                           return ItemContents{val, "DEAD"};
-                        else
-                           return ItemContents{val, std::to_string(val) + '%'};
-                     };
-    auto mk_age  = [](int val) {
-                      if(val == 100)
-                         return ItemContents{val, "???"};
-                      else
-                         return ItemContents{val, std::to_string(val)};
-                   };
-    auto mk_percent = [](int val) {
-                         return ItemContents{val, std::to_string(val) + '%'};
-                      };
-    auto mk_yesno = [](bool val) {
-                       return ItemContents{val, val ? "Yes" : "No"};
-                      };
 
     /* */if (detailName == "Name")     return mk_text(FullName());
     else if (detailName == "Health")   return mk_health(get_stat(STAT_HEALTH));
@@ -1039,10 +1021,6 @@ ItemContents sGirl::OutputGirlDetail(const std::string& detailName) const
 /// \param detailName Either "DayJob" or "NightJob".
 ItemContents sGirl::OutputGirlDetail_Job(std::string const& detailName) const
 {
-   auto mk_text = [](std::string str) {
-                     return ItemContents{str, str};
-                  };
-
    bool interrupted = false;    // `J` added
    if (m_YesterDayJob != m_DayJob &&
        (cJobManager::is_Surgery_Job(m_YesterDayJob) || m_YesterDayJob == JOB_REHAB) &&

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -834,297 +834,339 @@ bool sGirl::was_resting() const
     return m_PrevDayJob == JOB_RESTING    && m_PrevNightJob == JOB_RESTING;
 }
 
-void sGirl::OutputGirlDetailString(std::string& Data, const std::string& detailName) const
+/// Given a name of a detail (stat, skill, trait, etc.), returns its
+/// value as itself (`.val_`) and as a formatted string (`.fmt_`).
+ItemContents sGirl::OutputGirlDetail(const std::string& detailName) const
 {
-    //given a statistic name, set a string to a value that represents that statistic
-    static std::stringstream ss;
-    ss.str("");
+    auto mk_text = [](std::string str) {
+                      return ItemContents{str, str};
+                   };
+    auto mk_num = [](int val) {
+                     return ItemContents{val, std::to_string(val)};
+                  };
+    auto mk_health = [](int val) {
+                        if(val <= 0)
+                           return ItemContents{val, "DEAD"};
+                        else
+                           return ItemContents{val, std::to_string(val) + '%'};
+                     };
+    auto mk_age  = [](int val) {
+                      if(val == 100)
+                         return ItemContents{val, "???"};
+                      else
+                         return ItemContents{val, std::to_string(val)};
+                   };
+    auto mk_percent = [](int val) {
+                         return ItemContents{val, std::to_string(val) + '%'};
+                      };
+    auto mk_yesno = [](bool val) {
+                       return ItemContents{val, val ? "Yes" : "No"};
+                      };
 
-    bool interrupted = false;    // `J` added
-    if (m_YesterDayJob != m_DayJob &&
-        (cJobManager::is_Surgery_Job(m_YesterDayJob) || m_YesterDayJob == JOB_REHAB) &&
-        ((m_WorkingDay > 0) || m_PrevWorkingDay > 0))
-        interrupted = true;
-
-    /* */if (detailName == "Name")                { ss << FullName(); }
-    else if (detailName == "Health")            { if (get_stat(STAT_HEALTH) <= 0) ss << "DEAD"; else ss << get_stat(STAT_HEALTH) << "%"; }
-    else if (detailName == "Age")                { if (get_stat(STAT_AGE) == 100) ss << "???"; else ss << get_stat(STAT_AGE); }
-    else if (detailName == "Libido")            { ss << libido(); }
-    else if (detailName == "Rebel")                { ss << rebel(); }
-    else if (detailName == "Looks")                { ss << ((get_stat(STAT_BEAUTY) + get_stat(STAT_CHARISMA)) / 2) << "%"; }
-    else if (detailName == "Tiredness")            { ss << get_stat(STAT_TIREDNESS) << "%"; }
-    else if (detailName == "Happiness")            { ss << get_stat(STAT_HAPPINESS) << "%"; }
-    else if (detailName == "Virgin")            { ss << (is_virgin(*this) ? "Yes" : "No"); }
+    /* */if (detailName == "Name")     return mk_text(FullName());
+    else if (detailName == "Health")   return mk_health(get_stat(STAT_HEALTH));
+    else if (detailName == "Age")      return mk_age(get_stat(STAT_AGE));
+    else if (detailName == "Libido")   return mk_num(libido());
+    else if (detailName == "Rebel")    return mk_num(rebel());
+    else if (detailName == "Looks")
+    {
+       return mk_percent((get_stat(STAT_BEAUTY) + get_stat(STAT_CHARISMA)) / 2);
+    }
+    else if (detailName == "Tiredness")     return mk_percent(get_stat(STAT_TIREDNESS));
+    else if (detailName == "Happiness")     return mk_percent(get_stat(STAT_HAPPINESS));
+    else if (detailName == "Virgin")        return mk_yesno(is_virgin(*this));
     else if (detailName == "Weeks_Due")
     {
         if (is_pregnant())
         {
-            ss << get_preg_duration() - m_WeeksPreg;
+            return mk_num(get_preg_duration() - m_WeeksPreg);
         }
         else
         {
-            ss << "---";
+            return mk_text("---");
         }
     }
-    else if (detailName == "PregCooldown")        { ss << m_PregCooldown; }
+    else if (detailName == "PregCooldown")
+    {
+        return mk_num(m_PregCooldown);
+    }
     else if (detailName == "Accommodation")
     {
-        ss << cGirls::Accommodation(m_AccLevel);
+        return mk_text(cGirls::Accommodation(m_AccLevel));
     }
     else if (detailName == "Gold")
     {
         if (g_Game->gang_manager().GetGangOnMission(MISS_SPYGIRLS))
         {
-            ss << m_Money;
+            return mk_num(m_Money);
         }
         else
         {
-            ss << "???";
+            return mk_text("???");
         }
     }
-    else if (detailName == "Pay")                { ss << m_Pay; }
+    else if (detailName == "Pay")                { return mk_num(m_Pay); }
 
         // 'J' Added for .06.03.01
-    else if (detailName == "DayJobShort" || detailName == "NightJobShort")
+    else if (detailName == "DayJobShort")
     {
-        ss << g_Game->job_manager().get_job_brief(detailName == "DayJobShort" ? m_DayJob : m_NightJob);
+        return mk_text(g_Game->job_manager().get_job_brief(m_DayJob));
+    }
+    else if(detailName == "NightJobShort")
+    {
+        return mk_text(g_Game->job_manager().get_job_brief(m_NightJob));
     }
 
         // 'J' Girl Table job text
     else if (detailName == "DayJob" || detailName == "NightJob")
     {
-        bool DN_Day = detailName == "NightJob";
-        JOBS DN_Job = get_job(DN_Day);
-        const std::string& job_name = g_Game->job_manager().get_job_name(DN_Job);
-
-        // `J` When modifying Jobs, search for "J-Change-Jobs"  :  found in >>
-        if (DN_Job >= NUM_JOBS)
-        {
-            ss << "None";
-        }
-        else if (DN_Job == JOB_FAKEORGASM || DN_Job == JOB_SO_STRAIGHT || DN_Job == JOB_SO_BISEXUAL || DN_Job == JOB_SO_LESBIAN)
-        {
-            ss << job_name << " (" << m_WorkingDay << "%)";
-        }
-        else if (DN_Job == JOB_CUREDISEASES)
-        {
-            if (m_Building->num_girls_on_job(JOB_DOCTOR, DN_Day) > 0)
-            {
-                ss << job_name << " (" << m_WorkingDay << "%)";
-            }
-            else
-            {
-                ss << job_name << " (" << m_WorkingDay << "%) **";
-            }
-        }
-        else if (DN_Job == JOB_REHAB || DN_Job == JOB_ANGER || DN_Job == JOB_EXTHERAPY || DN_Job == JOB_THERAPY)
-        {
-            if (m_Building->num_girls_on_job(JOB_COUNSELOR, DN_Day) > 0)
-            {
-                ss << job_name << " (" << 3 - m_WorkingDay << ")";
-            }
-            else
-            {
-                ss << job_name << " (?)***";
-            }
-        }
-        else if (DN_Job == JOB_GETHEALING)
-        {
-            if (m_Building->num_girls_on_job(JOB_DOCTOR, DN_Day) > 0)
-            {
-                ss << job_name;
-            }
-            else
-            {
-                ss << job_name << " ***";
-            }
-        }
-        else if (DN_Job == JOB_GETREPAIRS)
-        {
-            if (m_Building->num_girls_on_job(JOB_MECHANIC, DN_Day) > 0 &&
-                (has_active_trait("Construct") || has_active_trait("Half-Construct")))
-            {
-                ss << job_name;
-            }
-            else if (has_active_trait("Construct"))
-            {
-                ss << job_name << " ****";
-            }
-            else
-            {
-                ss << job_name << " !!";
-            }
-        }
-        else if (DN_Job == JOB_GETABORT)
-        {
-            int wdays = (2 - (this)->m_WorkingDay);
-            if (m_Building->num_girls_on_job(JOB_NURSE, DN_Day) > 0)
-            {
-                wdays = 1;
-            }
-            if (m_Building->num_girls_on_job( JOB_DOCTOR, DN_Day) > 0)
-            {
-                ss << job_name << " (" << wdays << ")*";
-            }
-            else
-            {
-                ss << job_name << " (?)***";
-            }
-        }
-        else if (cJobManager::is_Surgery_Job(DN_Job))
-        {
-            int wdays = (5 - (this)->m_WorkingDay);
-            if (m_Building->num_girls_on_job(JOB_NURSE, DN_Day) > 0)
-            {
-                if (wdays >= 3)        { wdays = 3; }
-                else if (wdays > 1)    { wdays = 2; }
-                else                { wdays = 1; }
-            }
-            if (m_Building->num_girls_on_job(JOB_DOCTOR, DN_Day) > 0)
-            {
-                ss << job_name << " (" << wdays << ")*";
-            }
-            else
-            {
-                ss << job_name << " (?)***";
-            }
-        }
-        else if (is_Actress_Job(DN_Job) && CrewNeeded(*m_Building))
-        {
-            ss << job_name << " **";
-        }
-        else if (is_resting() && !was_resting() && m_PrevDayJob != 255 && m_PrevNightJob != 255)
-        {
-            ss << job_name;
-            ss << " (" << g_Game->job_manager().get_job_brief(DN_Day == 0 ? m_PrevDayJob : m_PrevNightJob) << ")";
-        }
-        else
-        {
-            ss << job_name;
-        }
-        if (interrupted)
-        {
-            ss << " **";
-        }
+        return OutputGirlDetail_Job(detailName);
     }
 
-    else if (detailName.find("STAT_") != std::string::npos)
+    else if (detailName.substr(0, 5) == "STAT_")
     {
-        std::string stat = detailName;
-        stat.replace(0, 5, "");
+        std::string stat = detailName.substr(5);
         int code = get_stat_id(stat);
         if (code != -1)
         {
-            ss << get_stat(code);
+            return mk_num(code);
         }
         else
         {
-            ss << "Error";
+            return mk_text("Error");
         }
     }
-    else if (detailName.find("SKILL_") != std::string::npos)
+    else if (detailName.substr(0, 6) == "SKILL_")
     {
-        std::string skill = detailName;
-        skill.replace(0, 6, "");
+        std::string skill = detailName.substr(6);;
         int code = get_skill_id(skill);
         if (code != -1)
         {
-            ss << get_skill(code);
+            return mk_num(code);
         }
         else
         {
-            ss << "Error";
+            return mk_text("Error");
         }
     }
-    else if (detailName.find("TRAIT_") != std::string::npos)
+    else if (detailName.substr(0, 6) == "TRAIT_")
     {
-        std::string trait = detailName;
-        trait.replace(0, 6, "");
-        if (this->has_active_trait(trait.c_str()))
-        {
-            ss << "Yes";
-        }
-        else
-        {
-            ss << "No";
-        }
+        std::string trait = detailName.substr(6);
+        return mk_yesno(this->has_active_trait(trait.c_str()));
     }
-    else if (detailName.find("STATUS_") != std::string::npos)
+    else if (detailName.substr(0, 7) == "STATUS_")
     {
-        std::string status = detailName;
-        status.replace(0, 7, "");
+        std::string status = detailName.substr(7);
         int code = get_status_id(status);
         if (code != -1)
         {
-            ss << (m_States&(1u << code) ? "Yes" : "No");
+            return mk_yesno(m_States & (1u << code));
         }
         else
         {
-            ss << "Error";
+            return mk_text("Error");
         }
     }
     else if (detailName == "is_pregnant")
     {
-        if (is_virgin(*this)) ss << "Vg.";
+        if (is_virgin(*this)) return mk_text("Vg.");
         else if (is_pregnant())
         {
-            int to_go = get_preg_duration() - (this)->m_WeeksPreg;
-            if (carrying_players_child())    ss << "Yours";
-            else if (carrying_monster())    ss << "Beast";
+            static std::ostringstream ss;
+
+            if (carrying_players_child())      ss << "Yours";
+            else if (carrying_monster())       ss << "Beast";
             else /*                      */    ss << "Yes";
+
+            int to_go = get_preg_duration() - (this)->m_WeeksPreg;
             if (has_active_trait("Sterile") || has_active_trait("Zombie") || has_active_trait("Skeleton"))
                 ss << "?" << to_go << "?";    // how?
             else
                 ss << "(" << to_go << ")";
+
+            return mk_text(ss.str());
         }
         else if (m_PregCooldown > 0)
         {
+            static std::ostringstream ss;
+
             ss << "No";
             if (has_active_trait("Sterile") || has_active_trait("Zombie") || has_active_trait("Skeleton"))
                 ss << "!" << m_PregCooldown << "!";
             else
                 ss << "(" << m_PregCooldown << ")";
+
+            return mk_text(ss.str());
         }
-        else if (has_active_trait("Zombie") || has_active_trait("Skeleton")) ss << "Ud.";
-        else if (has_active_trait("Sterile"))        ss << "St.";
-        else if (has_active_trait("Fertile"))      ss << "No+";
-        else if (has_active_trait("Broodmother"))  ss << "No++";
-        else                                ss << "No";
+        else if (has_active_trait("Zombie") || has_active_trait("Skeleton"))
+           return mk_text("Ud.");
+        else if (has_active_trait("Sterile"))      return mk_text("St.");
+        else if (has_active_trait("Fertile"))      return mk_text("No+");
+        else if (has_active_trait("Broodmother"))  return mk_text("No++");
+        else                                       return mk_text("No");
     }
-    else if (detailName == "is_slave")            { ss << (is_slave() ? "Yes" : "No"); }
-    else if (detailName == "carrying_human")    { ss << (carrying_human() ? "Yes" : "No"); }
-    else if (detailName == "is_addict")            { ss << (is_addict(*this) ? "Yes" : "No"); }
-    else if (detailName == "has_disease")        { ss << (has_disease(*this) ? "Yes" : "No"); }
-    else if (detailName == "is_mother")            { ss << (is_mother() ? "Yes" : "No"); }
-    else if (detailName == "is_poisoned")        { ss << (is_poisoned() ? "Yes" : "No"); }
+    else if (detailName == "is_slave")       return mk_yesno(is_slave());
+    else if (detailName == "carrying_human") return mk_yesno(carrying_human());
+    else if (detailName == "is_addict")      return mk_yesno(is_addict(*this));
+    else if (detailName == "has_disease")    return mk_yesno(has_disease(*this));
+    else if (detailName == "is_mother")      return mk_yesno(is_mother());
+    else if (detailName == "is_poisoned")    return mk_yesno(is_poisoned());
     else if (detailName == "Value")
     {
         // TODO this should not be modifying the girl
         cGirls::UpdateAskPrice(*const_cast<sGirl*>(this), false);
-        ss << (int)g_Game->tariff().slave_price(*const_cast<sGirl*>(this), false);
+        return mk_num((int)g_Game->tariff().slave_price(*const_cast<sGirl*>(this), false));
     }
     else if (detailName == "SO")
     {
-        /* */if (has_active_trait("Lesbian"))    ss << "L";
-        else if (has_active_trait("Straight"))    ss << "S";
-        else if (has_active_trait("Bisexual"))    ss << "B";
-        else/*                       */    ss << "-";
+       /* */if (has_active_trait("Lesbian"))    return mk_text("L");
+       else if (has_active_trait("Straight"))   return mk_text("S");
+       else if (has_active_trait("Bisexual"))   return mk_text("B");
+       else/*                       */          return mk_text("-");
     }
     else if (detailName == "SexAverage")
-    {
-        ss << (int)cGirls::GetAverageOfSexSkills(*this);
-    }
+        return mk_num((int)cGirls::GetAverageOfSexSkills(*this));
     else if (detailName == "NonSexAverage")
-    {
-        ss << (int)cGirls::GetAverageOfNSxSkills(*this);
-    }
+        return mk_num((int)cGirls::GetAverageOfNSxSkills(*this));
     else if (detailName == "SkillAverage")
-    {
-        ss << (int)cGirls::GetAverageOfAllSkills(*this);
-    }
-    else /*                            */        { ss << "Not found"; }
-    Data = ss.str();
+        return mk_num((int)cGirls::GetAverageOfAllSkills(*this));
+    else
+        return mk_text("Not found");
 }
+
+/// Builds the detail value for jobs and job-like activities.
+///
+/// \param detailName Either "DayJob" or "NightJob".
+ItemContents sGirl::OutputGirlDetail_Job(std::string const& detailName) const
+{
+   auto mk_text = [](std::string str) {
+                     return ItemContents{str, str};
+                  };
+
+   bool interrupted = false;    // `J` added
+   if (m_YesterDayJob != m_DayJob &&
+       (cJobManager::is_Surgery_Job(m_YesterDayJob) || m_YesterDayJob == JOB_REHAB) &&
+       ((m_WorkingDay > 0) || m_PrevWorkingDay > 0))
+      interrupted = true;
+
+   static std::ostringstream ss;
+
+   bool DN_Day = detailName == "NightJob";
+   JOBS DN_Job = get_job(DN_Day);
+   const std::string& job_name = g_Game->job_manager().get_job_name(DN_Job);
+
+   // `J` When modifying Jobs, search for "J-Change-Jobs"  :  found in >>
+   if (DN_Job >= NUM_JOBS)
+   {
+      ss << "None";
+   }
+   else if (DN_Job == JOB_FAKEORGASM || DN_Job == JOB_SO_STRAIGHT || DN_Job == JOB_SO_BISEXUAL || DN_Job == JOB_SO_LESBIAN)
+   {
+      ss << job_name << " (" << m_WorkingDay << "%)";
+   }
+   else if (DN_Job == JOB_CUREDISEASES)
+   {
+      if (m_Building->num_girls_on_job(JOB_DOCTOR, DN_Day) > 0)
+      {
+         ss << job_name << " (" << m_WorkingDay << "%)";
+      }
+      else
+      {
+         ss << job_name << " (" << m_WorkingDay << "%) **";
+      }
+   }
+   else if (DN_Job == JOB_REHAB || DN_Job == JOB_ANGER || DN_Job == JOB_EXTHERAPY || DN_Job == JOB_THERAPY)
+   {
+      if (m_Building->num_girls_on_job(JOB_COUNSELOR, DN_Day) > 0)
+      {
+         ss << job_name << " (" << 3 - m_WorkingDay << ")";
+      }
+      else
+      {
+         ss << job_name << " (?)***";
+      }
+   }
+   else if (DN_Job == JOB_GETHEALING)
+   {
+      if (m_Building->num_girls_on_job(JOB_DOCTOR, DN_Day) > 0)
+      {
+         ss << job_name;
+      }
+      else
+      {
+         ss << job_name << " ***";
+      }
+   }
+   else if (DN_Job == JOB_GETREPAIRS)
+   {
+      if (m_Building->num_girls_on_job(JOB_MECHANIC, DN_Day) > 0 &&
+          (has_active_trait("Construct") || has_active_trait("Half-Construct")))
+      {
+         ss << job_name;
+      }
+      else if (has_active_trait("Construct"))
+      {
+         ss << job_name << " ****";
+      }
+      else
+      {
+         ss << job_name << " !!";
+      }
+   }
+   else if (DN_Job == JOB_GETABORT)
+   {
+      int wdays = (2 - (this)->m_WorkingDay);
+      if (m_Building->num_girls_on_job(JOB_NURSE, DN_Day) > 0)
+      {
+         wdays = 1;
+      }
+      if (m_Building->num_girls_on_job( JOB_DOCTOR, DN_Day) > 0)
+      {
+         ss << job_name << " (" << wdays << ")*";
+      }
+      else
+      {
+         ss << job_name << " (?)***";
+      }
+   }
+   else if (cJobManager::is_Surgery_Job(DN_Job))
+   {
+      int wdays = (5 - (this)->m_WorkingDay);
+      if (m_Building->num_girls_on_job(JOB_NURSE, DN_Day) > 0)
+      {
+         if (wdays >= 3)        { wdays = 3; }
+         else if (wdays > 1)    { wdays = 2; }
+         else                { wdays = 1; }
+      }
+      if (m_Building->num_girls_on_job(JOB_DOCTOR, DN_Day) > 0)
+      {
+         ss << job_name << " (" << wdays << ")*";
+      }
+      else
+      {
+         ss << job_name << " (?)***";
+      }
+   }
+   else if (is_Actress_Job(DN_Job) && CrewNeeded(*m_Building))
+   {
+      ss << job_name << " **";
+   }
+   else if (is_resting() && !was_resting() && m_PrevDayJob != 255 && m_PrevNightJob != 255)
+   {
+      ss << job_name;
+      ss << " (" << g_Game->job_manager().get_job_brief(DN_Day == 0 ? m_PrevDayJob : m_PrevNightJob) << ")";
+   }
+   else
+   {
+      ss << job_name;
+   }
+   if (interrupted)
+   {
+      ss << " **";
+   }
+
+   return mk_text(ss.str());
+};
 
 int sGirl::rebel() const
 {

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -1049,7 +1049,7 @@ ItemContents sGirl::OutputGirlDetail_Job(std::string const& detailName) const
        ((m_WorkingDay > 0) || m_PrevWorkingDay > 0))
       interrupted = true;
 
-   static std::ostringstream ss;
+   std::ostringstream ss;
 
    bool DN_Day = detailName == "NightJob";
    JOBS DN_Job = get_job(DN_Day);

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -836,7 +836,7 @@ bool sGirl::was_resting() const
 
 /// Given a name of a detail (stat, skill, trait, etc.), returns its
 /// value as itself (`.val_`) and as a formatted string (`.fmt_`).
-FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
+FormattedCellData sGirl::GetDetail(const std::string& detailName) const
 {
     auto mk_age = [](int val) {
                      if(val == 100)
@@ -902,7 +902,7 @@ FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
         // 'J' Girl Table job text
     else if (detailName == "DayJob" || detailName == "NightJob")
     {
-        return OutputGirlDetail_Job(detailName);
+        return GetDetail_Job(detailName);
     }
 
     else if (detailName.substr(0, 5) == "STAT_")
@@ -1019,7 +1019,7 @@ FormattedCellData sGirl::OutputGirlDetail(const std::string& detailName) const
 /// Builds the detail value for jobs and job-like activities.
 ///
 /// \param detailName Either "DayJob" or "NightJob".
-FormattedCellData sGirl::OutputGirlDetail_Job(std::string const& detailName) const
+FormattedCellData sGirl::GetDetail_Job(std::string const& detailName) const
 {
    bool interrupted = false;    // `J` added
    if (m_YesterDayJob != m_DayJob &&

--- a/src/game/character/sGirl.h
+++ b/src/game/character/sGirl.h
@@ -266,10 +266,10 @@ struct sGirl : public ICharacter, public std::enable_shared_from_this<sGirl>
     bool is_havingsex() const;
     bool was_resting() const;
 
-    FormattedCellData OutputGirlDetail(const std::string& detailName) const;
+    FormattedCellData GetDetail(const std::string& detailName) const;
 
 private:
-    FormattedCellData OutputGirlDetail_Job(const std::string& detailName) const;
+    FormattedCellData GetDetail_Job(const std::string& detailName) const;
 
 public:
     // END MOD

--- a/src/game/character/sGirl.h
+++ b/src/game/character/sGirl.h
@@ -34,7 +34,7 @@
 #include "pregnancy.h"
 #include "utils/DirPath.h"
 
-#include "widgets/cListBox.h"
+#include "interface/TableCells.h"
 
 
 class TraitSpec;

--- a/src/game/character/sGirl.h
+++ b/src/game/character/sGirl.h
@@ -266,15 +266,10 @@ struct sGirl : public ICharacter, public std::enable_shared_from_this<sGirl>
     bool is_havingsex() const;
     bool was_resting() const;
 
-    void OutputGirlDetailString(std::string& Data, const std::string& detailName) const
-    {
-       Data = OutputGirlDetail(detailName).fmt_;
-    }
-
     ItemContents OutputGirlDetail(const std::string& detailName) const;
 
 private:
-   ItemContents OutputGirlDetail_Job(const std::string& detailName) const;
+    ItemContents OutputGirlDetail_Job(const std::string& detailName) const;
 
 public:
     // END MOD

--- a/src/game/character/sGirl.h
+++ b/src/game/character/sGirl.h
@@ -266,10 +266,10 @@ struct sGirl : public ICharacter, public std::enable_shared_from_this<sGirl>
     bool is_havingsex() const;
     bool was_resting() const;
 
-    ItemContents OutputGirlDetail(const std::string& detailName) const;
+    FormattedCellData OutputGirlDetail(const std::string& detailName) const;
 
 private:
-    ItemContents OutputGirlDetail_Job(const std::string& detailName) const;
+    FormattedCellData OutputGirlDetail_Job(const std::string& detailName) const;
 
 public:
     // END MOD

--- a/src/game/character/sGirl.h
+++ b/src/game/character/sGirl.h
@@ -34,6 +34,8 @@
 #include "pregnancy.h"
 #include "utils/DirPath.h"
 
+#include "widgets/cListBox.h"
+
 
 class TraitSpec;
 class sInventoryItem;
@@ -264,8 +266,17 @@ struct sGirl : public ICharacter, public std::enable_shared_from_this<sGirl>
     bool is_havingsex() const;
     bool was_resting() const;
 
-    void OutputGirlDetailString(std::string& Data, const std::string& detailName) const;
+    void OutputGirlDetailString(std::string& Data, const std::string& detailName) const
+    {
+       Data = OutputGirlDetail(detailName).fmt_;
+    }
 
+    ItemContents OutputGirlDetail(const std::string& detailName) const;
+
+private:
+   ItemContents OutputGirlDetail_Job(const std::string& detailName) const;
+
+public:
     // END MOD
 
     double job_performance(JOBS job, bool estimate=true) const;

--- a/src/game/screens/BuildingScreenManagement.cpp
+++ b/src/game/screens/BuildingScreenManagement.cpp
@@ -439,7 +439,7 @@ void IBuildingScreenManagement::init(bool back)
     // get a list of all the column names, so we can find which data goes in that column
     std::vector<std::string> columnNames = GetListBox(girllist_id)->GetColumnNames();
     int numColumns = columnNames.size();
-    std::vector<ItemContents> data(numColumns);
+    std::vector<FormattedCellData> data(numColumns);
 
     for (int i = 0; i < active_building().num_girls(); i++)    // Add girls to list
     {

--- a/src/game/screens/BuildingScreenManagement.cpp
+++ b/src/game/screens/BuildingScreenManagement.cpp
@@ -448,7 +448,7 @@ void IBuildingScreenManagement::init(bool back)
         unsigned int item_color = (gir->health() <= 30 || gir->tiredness() >= 80 || gir->happiness() <= 30) ? COLOR_RED : COLOR_BLUE;
         for (unsigned int x = 0; x < columnNames.size(); ++x)
         {
-            data[x] = gir->OutputGirlDetail(columnNames[x]);
+            data[x] = gir->GetDetail(columnNames[x]);
         }
         AddToListBox(girllist_id, i, data, item_color);
     }

--- a/src/game/screens/BuildingScreenManagement.cpp
+++ b/src/game/screens/BuildingScreenManagement.cpp
@@ -439,7 +439,7 @@ void IBuildingScreenManagement::init(bool back)
     // get a list of all the column names, so we can find which data goes in that column
     std::vector<std::string> columnNames = GetListBox(girllist_id)->GetColumnNames();
     int numColumns = columnNames.size();
-    std::vector<std::string> data(numColumns);
+    std::vector<ItemContents> data(numColumns);
 
     for (int i = 0; i < active_building().num_girls(); i++)    // Add girls to list
     {
@@ -448,7 +448,7 @@ void IBuildingScreenManagement::init(bool back)
         unsigned int item_color = (gir->health() <= 30 || gir->tiredness() >= 80 || gir->happiness() <= 30) ? COLOR_RED : COLOR_BLUE;
         for (unsigned int x = 0; x < columnNames.size(); ++x)
         {
-            gir->OutputGirlDetailString(data[x], columnNames[x]);
+            data[x] = gir->OutputGirlDetail(columnNames[x]);
         }
         AddToListBox(girllist_id, i, data, item_color);
     }

--- a/src/game/screens/cScreenDungeon.cpp
+++ b/src/game/screens/cScreenDungeon.cpp
@@ -174,7 +174,7 @@ void cScreenDungeon::init(bool back)
     selection = g_Game->dungeon().GetNumGirls() > 0 ? 0 : -1;
     for (int i = 0; i < g_Game->dungeon().GetNumGirls(); i++)                                                // add girls
     {
-        std::vector<std::string> Data;
+        std::vector<ItemContents> Data;
         sGirl *girl = g_Game->dungeon().GetGirl(i)->m_Girl.get();                                            // get the i-th girl
         if (selected_girl().get() == girl) selection = i;                                                            // if selected_girl is this girl, update selection
         girl->m_DayJob = girl->m_NightJob = JOB_INDUNGEON;
@@ -186,7 +186,7 @@ void cScreenDungeon::init(bool back)
     int offset = g_Game->dungeon().GetNumGirls();
     for (int i = 0; i < g_Game->dungeon().GetNumCusts(); i++)    // add customers
     {
-        std::vector<std::string> Data;
+        std::vector<ItemContents> Data;
         int col = (g_Game->dungeon().GetCust(i)->m_Health <= 30) ? COLOR_RED : COLOR_BLUE;
         g_Game->dungeon().OutputCustRow(i, Data, columnNames);
         AddToListBox(girllist_id, i + offset, std::move(Data), col);

--- a/src/game/screens/cScreenDungeon.cpp
+++ b/src/game/screens/cScreenDungeon.cpp
@@ -174,7 +174,7 @@ void cScreenDungeon::init(bool back)
     selection = g_Game->dungeon().GetNumGirls() > 0 ? 0 : -1;
     for (int i = 0; i < g_Game->dungeon().GetNumGirls(); i++)                                                // add girls
     {
-        std::vector<ItemContents> Data;
+        std::vector<FormattedCellData> Data;
         sGirl *girl = g_Game->dungeon().GetGirl(i)->m_Girl.get();                                            // get the i-th girl
         if (selected_girl().get() == girl) selection = i;                                                            // if selected_girl is this girl, update selection
         girl->m_DayJob = girl->m_NightJob = JOB_INDUNGEON;
@@ -186,7 +186,7 @@ void cScreenDungeon::init(bool back)
     int offset = g_Game->dungeon().GetNumGirls();
     for (int i = 0; i < g_Game->dungeon().GetNumCusts(); i++)    // add customers
     {
-        std::vector<ItemContents> Data;
+        std::vector<FormattedCellData> Data;
         int col = (g_Game->dungeon().GetCust(i)->m_Health <= 30) ? COLOR_RED : COLOR_BLUE;
         g_Game->dungeon().OutputCustRow(i, Data, columnNames);
         AddToListBox(girllist_id, i + offset, std::move(Data), col);

--- a/src/game/screens/cScreenGangs.cpp
+++ b/src/game/screens/cScreenGangs.cpp
@@ -226,23 +226,35 @@ void cScreenGangs::init(bool back)
     ClearListBox(ganglist_id);
     int num = 0;
 
+    auto mk_textitem = [](std::string str) {
+                          return ItemContents{str, str};
+                       };
+    auto mk_numitem  = [](int val) {
+                          return ItemContents{val, std::to_string(val)};
+                       };
+    auto mk_statitem = [](int val) {
+                          return ItemContents{val, std::to_string(val) + '%'};
+                       };
+
     // loop through the gangs, populating the list box
     g_LogFile.log(ELogLevel::DEBUG, "Setting gang mission descriptions\n");
     for(auto& gang : g_Game->gang_manager().GetPlayerGangs())
     {
         // format the string with the gang name, mission and number of men
-        std::vector<std::string> Data(11);
-        ss.str("");    ss << gang->name(); Data[0] = ss.str();
-        ss.str("");    ss << gang->m_Num; Data[1] = ss.str();
-        ss.str("");    ss << short_mission_desc(gang->m_MissionID); Data[2] = ss.str();
-        ss.str("");    ss << gang->m_Skills[SKILL_COMBAT] << "%"; Data[3] = ss.str();
-        ss.str("");    ss << gang->m_Skills[SKILL_MAGIC] << "%"; Data[4] = ss.str();
-        ss.str("");    ss << gang->m_Stats[STAT_INTELLIGENCE] << "%"; Data[5] = ss.str();
-        ss.str("");    ss << gang->m_Stats[STAT_AGILITY] << "%"; Data[6] = ss.str();
-        ss.str("");    ss << gang->m_Stats[STAT_CONSTITUTION] << "%"; Data[7] = ss.str();
-        ss.str("");    ss << gang->m_Stats[STAT_CHARISMA] << "%"; Data[8] = ss.str();
-        ss.str("");    ss << gang->m_Stats[STAT_STRENGTH] << "%"; Data[9] = ss.str();
-        ss.str("");    ss << gang->m_Skills[SKILL_SERVICE] << "%"; Data[10] = ss.str();
+        std::vector<ItemContents> Data(11);
+
+        Data[0]  = mk_textitem(gang->name());
+        Data[1]  = mk_numitem(gang->m_Num);
+        Data[2]  = mk_textitem(short_mission_desc(gang->m_MissionID));
+
+        Data[3]  = mk_statitem(gang->m_Skills[SKILL_COMBAT]);
+        Data[4]  = mk_statitem(gang->m_Skills[SKILL_MAGIC]);
+        Data[5]  = mk_statitem(gang->m_Stats[STAT_INTELLIGENCE]);
+        Data[6]  = mk_statitem(gang->m_Stats[STAT_AGILITY]);
+        Data[7]  = mk_statitem(gang->m_Stats[STAT_CONSTITUTION]);
+        Data[8]  = mk_statitem(gang->m_Stats[STAT_CHARISMA]);
+        Data[9]  = mk_statitem(gang->m_Stats[STAT_STRENGTH]);
+        Data[10] = mk_statitem(gang->m_Skills[SKILL_SERVICE]);
 
         //        cerr << "Gang:\t" << Data[0] << "\t" << Data[1] << "\t" << Data[2]
         //            << "\t" << Data[3] << "\t" << Data[4] << "\t" << Data[5] << "\t" << Data[6] << endl;

--- a/src/game/screens/cScreenGangs.cpp
+++ b/src/game/screens/cScreenGangs.cpp
@@ -226,16 +226,6 @@ void cScreenGangs::init(bool back)
     ClearListBox(ganglist_id);
     int num = 0;
 
-    auto mk_textitem = [](std::string str) {
-                          return ItemContents{str, str};
-                       };
-    auto mk_numitem  = [](int val) {
-                          return ItemContents{val, std::to_string(val)};
-                       };
-    auto mk_statitem = [](int val) {
-                          return ItemContents{val, std::to_string(val) + '%'};
-                       };
-
     // loop through the gangs, populating the list box
     g_LogFile.log(ELogLevel::DEBUG, "Setting gang mission descriptions\n");
     for(auto& gang : g_Game->gang_manager().GetPlayerGangs())
@@ -243,18 +233,18 @@ void cScreenGangs::init(bool back)
         // format the string with the gang name, mission and number of men
         std::vector<ItemContents> Data(11);
 
-        Data[0]  = mk_textitem(gang->name());
-        Data[1]  = mk_numitem(gang->m_Num);
-        Data[2]  = mk_textitem(short_mission_desc(gang->m_MissionID));
+        Data[0]  = mk_text(gang->name());
+        Data[1]  = mk_num(gang->m_Num);
+        Data[2]  = mk_text(short_mission_desc(gang->m_MissionID));
 
-        Data[3]  = mk_statitem(gang->m_Skills[SKILL_COMBAT]);
-        Data[4]  = mk_statitem(gang->m_Skills[SKILL_MAGIC]);
-        Data[5]  = mk_statitem(gang->m_Stats[STAT_INTELLIGENCE]);
-        Data[6]  = mk_statitem(gang->m_Stats[STAT_AGILITY]);
-        Data[7]  = mk_statitem(gang->m_Stats[STAT_CONSTITUTION]);
-        Data[8]  = mk_statitem(gang->m_Stats[STAT_CHARISMA]);
-        Data[9]  = mk_statitem(gang->m_Stats[STAT_STRENGTH]);
-        Data[10] = mk_statitem(gang->m_Skills[SKILL_SERVICE]);
+        Data[3]  = mk_percent(gang->m_Skills[SKILL_COMBAT]);
+        Data[4]  = mk_percent(gang->m_Skills[SKILL_MAGIC]);
+        Data[5]  = mk_percent(gang->m_Stats[STAT_INTELLIGENCE]);
+        Data[6]  = mk_percent(gang->m_Stats[STAT_AGILITY]);
+        Data[7]  = mk_percent(gang->m_Stats[STAT_CONSTITUTION]);
+        Data[8]  = mk_percent(gang->m_Stats[STAT_CHARISMA]);
+        Data[9]  = mk_percent(gang->m_Stats[STAT_STRENGTH]);
+        Data[10] = mk_percent(gang->m_Skills[SKILL_SERVICE]);
 
         //        cerr << "Gang:\t" << Data[0] << "\t" << Data[1] << "\t" << Data[2]
         //            << "\t" << Data[3] << "\t" << Data[4] << "\t" << Data[5] << "\t" << Data[6] << endl;

--- a/src/game/screens/cScreenGangs.cpp
+++ b/src/game/screens/cScreenGangs.cpp
@@ -231,7 +231,7 @@ void cScreenGangs::init(bool back)
     for(auto& gang : g_Game->gang_manager().GetPlayerGangs())
     {
         // format the string with the gang name, mission and number of men
-        std::vector<ItemContents> Data(11);
+        std::vector<FormattedCellData> Data(11);
 
         Data[0]  = mk_text(gang->name());
         Data[1]  = mk_num(gang->m_Num);

--- a/src/game/screens/cScreenTransfer.cpp
+++ b/src/game/screens/cScreenTransfer.cpp
@@ -145,7 +145,7 @@ void cScreenTransfer::select_brothel(Side side, int selected)
             std::vector<FormattedCellData> Data(columnNames.size());
             for (unsigned int x = 0; x < columnNames.size(); ++x)
             {
-                Data[x] = girl.OutputGirlDetail(columnNames[x]);
+                Data[x] = girl.GetDetail(columnNames[x]);
             }
             AddToListBox(own_list_id, i, std::move(Data), checkjobcolor(girl));
             i++;

--- a/src/game/screens/cScreenTransfer.cpp
+++ b/src/game/screens/cScreenTransfer.cpp
@@ -142,7 +142,7 @@ void cScreenTransfer::select_brothel(Side side, int selected)
         int i = 0;
         temp->girls().visit([&](const sGirl& girl) {
             if (selected_girl().get() == &girl) selection = i;
-            std::vector<ItemContents> Data(columnNames.size());
+            std::vector<FormattedCellData> Data(columnNames.size());
             for (unsigned int x = 0; x < columnNames.size(); ++x)
             {
                 Data[x] = girl.OutputGirlDetail(columnNames[x]);

--- a/src/game/screens/cScreenTransfer.cpp
+++ b/src/game/screens/cScreenTransfer.cpp
@@ -142,10 +142,10 @@ void cScreenTransfer::select_brothel(Side side, int selected)
         int i = 0;
         temp->girls().visit([&](const sGirl& girl) {
             if (selected_girl().get() == &girl) selection = i;
-            std::vector<std::string> Data(columnNames.size());
+            std::vector<ItemContents> Data(columnNames.size());
             for (unsigned int x = 0; x < columnNames.size(); ++x)
             {
-                girl.OutputGirlDetailString(Data[x], columnNames[x]);
+                Data[x] = girl.OutputGirlDetail(columnNames[x]);
             }
             AddToListBox(own_list_id, i, std::move(Data), checkjobcolor(girl));
             i++;


### PR DESCRIPTION
This gives us
 - Well-defined sorting order, across, and between, all types.
   - The types belong to the cells, not the columns.
   - Mixed-type columns are perfectly fine (but might look a little strange when displayed).
- The sort function no longer need to parse the formatted text.
   - So parse failures cannot happen anymore.
   - So it is now _nothrow_ exception-safe (unless we make `operator<()` throw :smiling_imp: )

One downside is that when a string is held, two copies are kept -- one in `val_` and one in `fmt_`. I did an experiment where I made strings into a cute special case, but it didn't work out (more complexity, and I still had to make the extra copy at the end).

What remains is cleaning it up (better names, better places for the new types, add doc blocks), extending it to the other tables (now, only the "Controlled Gangs" table actually uses it), and removing the old column-type scheme.