### PR TITLE
Modernizing cRng and leaving rand() behind.

### DIFF
--- a/src/engine/cRng.cpp
+++ b/src/engine/cRng.cpp
@@ -16,7 +16,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include"cRng.h"
+
+#include <list>
+#include <cmath>
+
+#include "cRng.h"
+
+#include "doctest.h"
 
 int cRng::in_range(int min, int max, int range)
 {
@@ -81,9 +87,55 @@ int cRng::gauss(int lo, int hi)
    return val;
 }
 
-const char* cRng::select_text(std::initializer_list<const char*> options) {
-    auto option = random(options.size());
-    return *(options.begin() + option);
+TEST_CASE("cRng singleton intervals")
+{
+   cRng rng;
+
+   double d1 = 3.5;
+   double d2 = std::nextafter(d1, 100.0);
+   for(size_t i = 0; i < 10'000; ++i)
+   {
+      CHECK(rng.random(1) == 0);
+      CHECK(rng.flat(5, 5) == 5);
+      CHECK(rng.flat(d1, d2) == d1);
+      CHECK(rng.percent(100) == true);
+      CHECK(rng.percent(0) == false);
+      CHECK(rng.one_of({12}) == 12);
+   }
+}
+
+TEST_CASE("cRng::one_of")
+{
+   if(false)               // compile-time test of the template magic.
+   {
+      cRng rng;
+
+      {
+         std::vector<int> v;
+         auto x = rng.one_of(begin(v), end(v));
+         x = rng.one_of(v);
+         rng.one_of(v) = 42;
+      }
+
+      {
+         int v[] = {1, 2, 3};
+         auto x = rng.one_of(std::begin(v), std::end(v));
+         x = rng.one_of(v);
+         rng.one_of(v) = 42;
+      }
+
+      {
+         std::list<int> v;
+         auto x = rng.one_of(begin(v), end(v));
+         x = rng.one_of(v);
+         rng.one_of(v) = 42;
+      }
+
+      {
+         auto text = rng.one_of({"this", "that", "the other"});
+         auto x = rng.one_of({10, 20, 30, 40});
+      }
+   }
 }
 
 //end mod

--- a/src/engine/cRng.cpp
+++ b/src/engine/cRng.cpp
@@ -17,26 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include"cRng.h"
-#include <ctime>
-
-/*
- * easier to use the method internally than an operator
- * (OK - I could use (*this) % foo, but that's messy...)
- */
-int cRng::random(int n)
-{
-    float scaling_factor = rand() / float(RAND_MAX);
-    if (scaling_factor == 1) scaling_factor = 0.9999f;
-    return  int(scaling_factor * n);
-}
-double cRng::randomd(double n)
-{
-    float scaling_factor = rand() / float(RAND_MAX);
-    if (scaling_factor == 1) scaling_factor = 0.9999f;
-    return  double(scaling_factor * n);
-}
-
-
 
 int cRng::in_range(int min, int max, int range)
 {
@@ -64,23 +44,6 @@ int cRng::bell(int min, int max)    // `J` added - not sure how well it will wor
     if (test < min)    return min;
     if (test > max) return max;
     return (int)test;
-}
-#if 0
-int cRng::bell(int min, int max, int mid)
-{
-    if (min == max) return max;
-    return min + random(bdif);
-}
-int cRng::bell(int min, int max, int mlo, int mhi)
-{
-    if (min == max) return max;
-    return min + random(bdif);
-}
-#endif
-
-cRng::cRng()
-{
-    srand((int)time(nullptr));
 }
 
 const char* cRng::select_text(std::initializer_list<const char*> options) {

--- a/src/engine/cRng.cpp
+++ b/src/engine/cRng.cpp
@@ -52,9 +52,6 @@ int cRng::gauss(int lo, int hi)
    // Sum this many flat dists together.
    constexpr const size_t n = 4;
 
-   auto lo1 = lo / n;
-   auto hi1 = hi / n;
-
    // find (lo, hi) ends for the sub-dists
    std::array<int, n> lo_i = {};
    std::array<int, n> hi_i = {};

--- a/src/engine/cRng.cpp
+++ b/src/engine/cRng.cpp
@@ -46,6 +46,44 @@ int cRng::bell(int min, int max)    // `J` added - not sure how well it will wor
     return (int)test;
 }
 
+// fake a Gaussian distribution by summing uniform ones.
+int cRng::gauss(int lo, int hi)
+{
+   // Sum this many flat dists together.
+   constexpr const size_t n = 4;
+
+   auto lo1 = lo / n;
+   auto hi1 = hi / n;
+
+   // find (lo, hi) ends for the sub-dists
+   std::array<int, n> lo_i = {};
+   std::array<int, n> hi_i = {};
+
+   // split the endpoints `n` ways
+   for(size_t i = 0; i < n; ++i)
+   {
+      lo_i[i] = lo / n;
+      hi_i[i] = hi / n;
+   }
+
+   // hand out the remainders
+   for(size_t i = 0; i < lo % n; ++i)
+      ++lo_i[i];
+   for(size_t i = 0; i < hi % n; ++i)
+      ++hi_i[i];
+
+   // it should sum up
+   assert(std::accumulate(begin(lo_i), end(lo_i), 0) == lo);
+   assert(std::accumulate(begin(hi_i), end(hi_i), 0) == hi);
+
+   // now loop and build the random number
+   int val = 0;
+   for(size_t i = 0; i < n; ++i)
+      val += flat(lo_i[i], hi_i[i]);
+
+   return val;
+}
+
 const char* cRng::select_text(std::initializer_list<const char*> options) {
     auto option = random(options.size());
     return *(options.begin() + option);

--- a/src/engine/include/cRng.h
+++ b/src/engine/include/cRng.h
@@ -154,7 +154,7 @@ struct cRng
     /// Simulates a d100 die.
     ///
     /// The returned random integer `x` is within `1 <= x <= 100`.
-    int d100() { return random(100) + 1; }
+    int d100() { return flat(1, 100); }
 /*
  *    constructor and destructor
  */

--- a/src/engine/include/cRng.h
+++ b/src/engine/include/cRng.h
@@ -31,7 +31,7 @@
  
 struct cRng
 {
-  std::mt19937 gen_;
+  std::ranlux48 gen_;
 
 /*
  *    changed this to be the base random number generator 

--- a/src/engine/include/cRng.h
+++ b/src/engine/include/cRng.h
@@ -89,6 +89,16 @@ struct cRng
     /// algorithm.
     int in_range(int min, int max, int range=101);
 
+    /// Returns a random integer `x` within `lo <= x <= hi` (a closed
+    /// interval).
+    ///
+    /// All integers within the interval has the same probability.
+    int flat(int lo, int hi)
+    {
+        std::uniform_int_distribution<> dist(lo, hi);
+        return dist(gen_);
+    }
+
 /*
  *    `J` trying to add a bell curve
 */
@@ -102,6 +112,13 @@ struct cRng
     /// \note I believe the author was trying for a Gaussian ("bell")
     /// distribution.
     int bell(int min, int max);
+
+    /// Returns a random integer `x` within `lo <= x <= hi` (a closed
+    /// interval).
+    ///
+    /// This distribution is better at faking a Gaussian distribution,
+    /// with the mid-point `(lo + hi)/2` as the average.
+    int gauss(int lo, int hi);
 
 /*
  *    returns true n percent of the time. 

--- a/src/game/cGirlGangFight.cpp
+++ b/src/game/cGirlGangFight.cpp
@@ -38,7 +38,7 @@ EGirlEscapeAttemptResult AttemptEscape(sGirl& girl) {
     std::vector<sGang*> v = g_Game->gang_manager().gangs_on_mission(MISS_GUARDING);
     if (!v.empty())
     {
-        int index = g_Dice.in_range(0, v.size() - 1);
+        int index = g_Dice.random(v.size());
         sGang *gang = v[index];
         g_LogFile.log(ELogLevel::DEBUG, "cGirlGangFight: random gang index = ", index, " gang = ", gang->name());
 

--- a/src/game/cGirlTorture.cpp
+++ b/src/game/cGirlTorture.cpp
@@ -258,7 +258,7 @@ void cGirlTorture::AddTextPlayer()
 {
     bool was, is;
 
-    int mes = g_Dice.in_range(0, 4);
+    int mes = g_Dice.flat(0, 4);
     switch (mes) {
     case 0:
         m_Message += "you torture her for hours leaving her sobbing.\n";

--- a/src/game/cJobManager.cpp
+++ b/src/game/cJobManager.cpp
@@ -863,7 +863,7 @@ bool cJobManager::work_related_violence(sGirl& girl, bool Day0Night1, bool stree
         // the security girl or defending gang is defeated, any casualties they inflicts
         // carry over to the next layer of defense.
         sGang *enemy_gang = g_Game->gang_manager().GetTempWeakGang();
-        enemy_gang->give_potions(g_Dice.in_range(1, 10));
+        enemy_gang->give_potions(g_Dice.flat(1, 10));
         enemy_gang->m_Skills[SKILL_MAGIC] = 0;
         // There is also between 1 and 10 of them, not 10 every time
         enemy_gang->m_Num = std::max(1, g_Dice.bell(-5, 10));

--- a/src/game/cNameList.cpp
+++ b/src/game/cNameList.cpp
@@ -79,6 +79,5 @@ string cNameList::random()
     /*
     *    otherwise, pick a random name
     */
-    unsigned size = m_names.size();
-    return m_names[g_Dice.random(size - 1)];  // edited from size to size-1 since I got an OOB vector crash once
+    return m_names[g_Dice.random(m_names.size())];
 }

--- a/src/game/cRival.cpp
+++ b/src/game/cRival.cpp
@@ -58,9 +58,16 @@ std::string cRivalManager::rivals_plunder_pc_gold(cRival* rival)
     if (g_Game->gold().ival() <= 0) return "";                        // no gold to sieze? nothing to do.
     long pc_gold = g_Game->gold().ival();                            // work out how much they take. make a note of how much we have
 
-    long gold = g_Dice.random(std::min((long)2000, pc_gold));
-    if (gold < 45) gold = 45;                                // make sure there's at least 45 gold taken
-    if (pc_gold < gold) gold = pc_gold;                        // unless the pc has less than that, in which case take the lot
+    long gold;
+    if(pc_gold <= 45)
+    {
+       gold = pc_gold;          //  take the lot
+    }
+    else
+    {                           // take 45...2000 gold
+       gold = g_Dice.flat(45, std::min((long)2000, pc_gold));
+    }
+
     g_Game->gold().rival_raids(gold);                                // deduct the losses against rival raid losses
     rival->m_Gold += gold;                                    // add the aount to rival coffers
 

--- a/src/game/character/cCustomers.cpp
+++ b/src/game/character/cCustomers.cpp
@@ -94,8 +94,8 @@ void sCustomer::Setup(int social_class, IBuilding& brothel)
     }
 
     // get their stats generated
-    for (auto& m_Stat : m_Stats)    m_Stat.m_Value = g_Dice.in_range(10, 100);
-    for (auto& m_Skill : m_Skills)    m_Skill.m_Value = g_Dice.in_range(10, 100);
+    for (auto& m_Stat : m_Stats)    m_Stat.m_Value = g_Dice.flat(10, 100);
+    for (auto& m_Skill : m_Skills)    m_Skill.m_Value = g_Dice.flat(10, 100);
 
     SetGoals();
 

--- a/src/game/character/sGirl.cpp
+++ b/src/game/character/sGirl.cpp
@@ -738,7 +738,7 @@ bool sGirl::calc_group_pregnancy(cPlayer* player, double factor)
 {
     double girl_chance = fertility(*this);
     sPercent guy_chance = g_Game->settings().get_percent(settings::PREG_CHANCE_PLAYER);
-    int n_guys = g_Dice.in_range(3,6); // the player, and a few more dudes
+    int n_guys = g_Dice.flat(3,5); // the player, and a few more dudes
     float chance = girl_chance * (1.f - std::pow(1.f - float(guy_chance), n_guys)) * factor;
 
     // now do the calculation

--- a/src/game/combat/action.cpp
+++ b/src/game/combat/action.cpp
@@ -194,8 +194,8 @@ ActionResult PhysicalAttack::calc_score(Combatant& self, Combatant& target) cons
 }
 
 void PhysicalAttack::do_act(Combatant& self, Combatant& target) const {
-    double parry = parry_chance(self, target) + rng().in_range(-5, 5) / 100.0;
-    double evade = evade_chance(self, target) + rng().in_range(-5, 5) / 100.0;
+    double parry = parry_chance(self, target) + rng().flat(-5, 5) / 100.0;
+    double evade = evade_chance(self, target) + rng().flat(-5, 5) / 100.0;
     bool feeble = false;
     int followed = 0;
 
@@ -211,7 +211,7 @@ void PhysicalAttack::do_act(Combatant& self, Combatant& target) const {
         followed = 50;
 
         // cause the pursuer to spend even more vitality points
-        int run_away = rng().in_range( 10 + 25 * target.get_agility(), 20 + 75 * target.get_agility() );
+        int run_away = rng().flat( 10 + 25 * target.get_agility(), 20 + 75 * target.get_agility() );
         if(target.get_vitality() > run_away / 2) {
             target.use_vitality(run_away / 2);
             if (self.get_vitality() < run_away * 1.5) {
@@ -262,7 +262,7 @@ void PhysicalAttack::do_act(Combatant& self, Combatant& target) const {
 
     target.inc_crowding();
     int dev = (100 - target.get_smarts()) / 10;
-    bool should_parry = 100 * parry + rng().in_range(0, dev) > 100 * evade + rng().in_range(0, dev);
+    bool should_parry = 100 * parry + rng().flat(0, dev) > 100 * evade + rng().flat(0, dev);
 
     // surrender?
     if(self.get_party()->aim == ECombatObjective::CAPTURE) {
@@ -315,7 +315,7 @@ void PhysicalAttack::do_act(Combatant& self, Combatant& target) const {
             narration() << " Critical Hit!";
         }
 
-        damage = rng().in_range(0.5*damage, 1.5*damage);
+        damage = rng().flat(0.5*damage, 1.5*damage);
 
         if(!target.hurt(damage, self)) {
             narration() << " " << target.get_name() << " takes " << damage << " damage.";
@@ -390,8 +390,8 @@ void MagicalAttack::do_act(Combatant& self, Combatant& target) const {
         return;
     }
 
-    double parry = deflect(self, target) + rng().in_range(-5, 5) / 100.0;
-    double evade = std::max(0.0, evade_chance(self, target) + rng().in_range(-5, 5) / 100.0);
+    double parry = deflect(self, target) + rng().flat(-5, 5) / 100.0;
+    double evade = std::max(0.0, evade_chance(self, target) + rng().flat(-5, 5) / 100.0);
     bool smart = rng().percent(target.get_smarts());
     bool success = false;
 
@@ -438,7 +438,7 @@ void MagicalAttack::do_act(Combatant& self, Combatant& target) const {
     if(success) {
         // damage target
         int damage = expected_damage(self, target);
-        damage = rng().in_range(0.5*damage, 1.5*damage);
+        damage = rng().flat(0.5*damage, 1.5*damage);
         if(!target.hurt(damage, self)) {
             narration() << " " << target.get_name() << " takes " << damage << " damage.";
         } else {

--- a/src/game/combat/combat.cpp
+++ b/src/game/combat/combat.cpp
@@ -290,9 +290,9 @@ void Combat::add_combatants(ECombatSide side, sGang& gang, int chance) {
         int strength = mage ? rng() % gang.strength() : gang.strength();
 
         auto& cbt = add_combatant(side, std::make_unique<Combatant>( g_BoysNameList.random(),
-                rng().in_range(50, 100),
-                rng().in_range(magic / 2, magic),
-                rng().in_range(5, 20), constitution, combat, magic, gang.agility(),
+                rng().flat(50, 100),
+                rng().flat(magic / 2, magic),
+                rng().flat(5, 20), constitution, combat, magic, gang.agility(),
                 strength
                 ));
         cbt.set_gang(&gang);

--- a/src/game/combat/traits.h
+++ b/src/game/combat/traits.h
@@ -39,7 +39,7 @@ namespace ct {
     if (m_girl->has_trait("Fearless"))        m_odds += 0.10;
     if (m_girl->has_trait("Fleet of Foot"))    m_odds += 0.10;
     if (m_girl->has_trait("Brawler"))        m_odds += 0.15;
-    if (m_girl->has_trait("Assassin"))        casualties += g_Dice.in_range(1, 6);
+    if (m_girl->has_trait("Assassin"))        casualties += g_Dice.flat(1, 5);
     if (m_girl->has_trait("Adventurer"))    casualties += 2;    // some level clearing instincts
     if (m_girl->has_trait("Merciless"))        casualties++;
     if (m_girl->has_trait("Yandere"))        casualties++;

--- a/src/game/gang_missions.cpp
+++ b/src/game/gang_missions.cpp
@@ -340,7 +340,7 @@ bool cMissionSabotage::execute_mission(sGang& gang, std::stringstream& ss)
     {
         // mod: brighter goons do better damage they need 100% to be better than before however
         int spread = gang.intelligence() / 4;
-        int num = 1 + g_Dice.random(spread);    // get the number of businesses lost
+        int num = g_Dice.flat(1, spread);    // get the number of businesses lost
         if (rival->m_BusinessesExtort < num)  // Can't destroy more businesses than they have
             num = rival->m_BusinessesExtort;
         rival->m_BusinessesExtort -= num;
@@ -739,7 +739,7 @@ bool cMissionPettyTheft::execute_mission(sGang& gang, std::stringstream& ss)
             girl->health(100);
             girl->tiredness(-100);
             auto health_potion = g_Game->inventory_manager().GetItem("Healing Salve (S)");
-            girl->add_item(health_potion, g_Dice.in_range(2, 4));
+            girl->add_item(health_potion, g_Dice.flat(2, 4));
 
             ss << "Your men are confronted by a masked vigilante.\n";
 

--- a/src/game/jobs/JobData.cpp
+++ b/src/game/jobs/JobData.cpp
@@ -78,7 +78,7 @@ void cJobGains::apply(sGirl& girl) const {
     if (girl.has_active_trait("Quick Learner"))        { xp += 3; learner = QUICK; }
     else if (girl.has_active_trait("Slow Learner"))    { xp -= 3; learner = SLOW; }
 
-    girl.exp(g_Dice.in_range(1, xp));
+    girl.exp(g_Dice.flat(1, xp));
 
     if(!Gains.empty()) {
         while (skill > 0) {

--- a/src/game/jobs/WorkFightArenaGirls.cpp
+++ b/src/game/jobs/WorkFightArenaGirls.cpp
@@ -73,9 +73,9 @@ bool WorkFightArenaGirls(sGirl& girl, bool Day0Night1, cRng& rng)
                 std::stringstream msg;    // goes to the girl and the g_MessageQue
                 std::stringstream Umsg;    // goes to the new girl
                 std::stringstream Tmsg;    // temp msg
-                ugirl->set_stat(STAT_HEALTH, rng.in_range(1, 50));
-                ugirl->set_stat(STAT_HAPPINESS, rng.in_range(1, 80));
-                ugirl->set_stat(STAT_TIREDNESS, rng.in_range(50, 100));
+                ugirl->set_stat(STAT_HEALTH, rng.flat(1, 50));
+                ugirl->set_stat(STAT_HAPPINESS, rng.flat(1, 80));
+                ugirl->set_stat(STAT_TIREDNESS, rng.flat(50, 100));
                 ugirl->set_status(STATUS_ARENA);
                 msg << "${name} won her fight against " << ugirl->FullName() << ".\n \n";
                 Umsg << ugirl->FullName() << " lost her fight against your girl ${name}.\n \n";

--- a/src/game/jobs/WorkFightBeast.cpp
+++ b/src/game/jobs/WorkFightBeast.cpp
@@ -92,8 +92,8 @@ bool WorkFightBeast(sGirl& girl, bool Day0Night1, cRng& rng)
     Combat combat(ECombatObjective::KILL, ECombatObjective::KILL);
     combat.add_combatant(ECombatSide::ATTACKER, girl);
     auto beast = std::make_unique<Combatant>("Beast", 100, 0, 0,
-            g_Dice.in_range(40, 80), g_Dice.in_range(40, 80), 0,
-            g_Dice.in_range(40, 80), g_Dice.in_range(40, 80));
+            g_Dice.flat(40, 80), g_Dice.flat(40, 80), 0,
+            g_Dice.flat(40, 80), g_Dice.flat(40, 80));
     combat.add_combatant(ECombatSide::DEFENDER, std::move(beast));
 
     auto result = combat.run(15);

--- a/src/game/jobs/WorkPersonalBedWarmer.cpp
+++ b/src/game/jobs/WorkPersonalBedWarmer.cpp
@@ -1244,13 +1244,13 @@ bool WorkPersonalBedWarmer(sGirl& girl, bool Day0Night1, cRng& rng)
     //BSIN bit more randomness
     if (is_addict(girl, true) && rng.percent(20))
     {
-        int theft = rng.in_range(5, 50);
+        int theft = rng.flat(5, 50);
         ss << "\nWhile you're not looking, she steals " << theft << " gold from your room to feed her addiction.\n";
         wages += theft;
     }
     if (rng.percent(30) && girl.has_active_trait("Natural Pheromones"))
     {
-        int wowfactor = rng.in_range(5, 55);
+        int wowfactor = rng.flat(5, 55);
         ss << "\nSomething about her drives you wild. You pay her " << wowfactor << " gold extra.\n";
         wages += wowfactor;
     }

--- a/src/game/screens/cScreenNewGame.cpp
+++ b/src/game/screens/cScreenNewGame.cpp
@@ -65,8 +65,8 @@ void cScreenNewGame::init(bool back)
     LoadNames();
     if(!back) {
         g_Game = std::make_unique<Game>();
-        g_Game->player().SetBirthDay(g_Dice.in_range(1, 30));
-        g_Game->player().SetBirthMonth(g_Dice.in_range(1, 12));
+        g_Game->player().SetBirthDay(g_Dice.flat(1, 30));
+        g_Game->player().SetBirthMonth(g_Dice.flat(1, 12));
         g_Game->player().SetName(g_BoysNameList.random(), " ", g_SurnameList.random());
     }
     update_ui();


### PR DESCRIPTION
 - The Mersenne Twister is definitely big. If we were to create multiple `cRng` instances that would be a problem, otherwise we're fine here.
 - `gauss()` is better at matching the bell curve than `bell()`, while still being reasonably fast.
 - I've found myself preferring closed intervals when working with random numbers, and I think that some of the bugs I've fixed lately agree with me there. So both `flat()` and `gauss()` use closed intervals.