### PR TITLE
[FIX] Proper handling of building interaction

### DIFF
--- a/src/game/jobs/GenericJob.cpp
+++ b/src/game/jobs/GenericJob.cpp
@@ -139,7 +139,7 @@ sGirl* IGenericJob::RequestInteraction(const std::string& name) {
 bool IGenericJob::HasInteraction(const std::string& name) const {
     auto brothel = active_girl().m_Building;
     assert(brothel);
-    return brothel->RequestInteraction(name);
+    return brothel->HasInteraction(name);
 }
 
 class cJobWrapper: public IGenericJob {


### PR DESCRIPTION
Warning!!! I found this bug while debugging, but I still haven't properly tested the fix. It seems pretty obvious, but i don't know if any code was depending on this bug to function. 

It took me a while to find out why 2 doctors where only providing 1 surgery
It turns out that when a check occurs to look for an interaction in job
(IGenericJob::HasInteraction) it was calling the request (IBuilding::RequestInteraction)
of the building, using the worker instead of just checking for its existence.
The return of RequestInteraction(non null pointer if existing, or null pointer if not)
was perfectly matching what was expected as a boolean, further obfuscating this issue.